### PR TITLE
Add evaluation and progress forms

### DIFF
--- a/database/queries.sql
+++ b/database/queries.sql
@@ -10,3 +10,33 @@ SELECT `id_area`, `nombre_area`, `descripcion` FROM `exp_areas_evaluacion` WHERE
 
 -- evaluaciones
 SELECT `id_evaluacion`, `id_nino`, `id_usuario`, `id_area`, `fecha`, `observaciones` FROM `exp_evaluaciones` WHERE 1;
+
+-- valoraciones por sesión
+CREATE TABLE `exp_valoraciones_sesion` (
+    `id_valoracion` INT AUTO_INCREMENT PRIMARY KEY,
+    `id_nino` INT NOT NULL,
+    `id_usuario` INT NOT NULL,
+    `participacion` TINYINT,
+    `atencion` TINYINT,
+    `tarea_casa` TINYINT,
+    `observaciones` TEXT,
+    `fecha_valoracion` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (`id_nino`) REFERENCES `nino`(`Id`),
+    FOREIGN KEY (`id_usuario`) REFERENCES `Usuarios`(`id_usuario`)
+);
+
+-- progreso general del paciente
+CREATE TABLE `exp_progreso_general` (
+    `id_progreso` INT AUTO_INCREMENT PRIMARY KEY,
+    `id_nino` INT NOT NULL,
+    `id_usuario` INT NOT NULL,
+    `lenguaje` TINYINT,
+    `motricidad` TINYINT,
+    `atencion` TINYINT,
+    `memoria` TINYINT,
+    `social` TINYINT,
+    `observaciones` TEXT,
+    `fecha_registro` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (`id_nino`) REFERENCES `nino`(`Id`),
+    FOREIGN KEY (`id_usuario`) REFERENCES `Usuarios`(`id_usuario`)
+);

--- a/includes/modalEvaluacion.php
+++ b/includes/modalEvaluacion.php
@@ -1,69 +1,45 @@
-<div class="modal fade" id="modalForm" style="display: none;" aria-hidden="true">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
+<div class="modal fade" id="modalForm" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <form method="POST" action="guardar_evaluacion.php" class="form-validate">
                 <div class="modal-header">
-                    <h5 class="modal-title">Customer Info</h5>
+                    <h5 class="modal-title">Nueva evaluación</h5>
                     <a href="#" class="close" data-bs-dismiss="modal" aria-label="Close">
                         <em class="icon ni ni-cross"></em>
                     </a>
                 </div>
                 <div class="modal-body">
-                    <form action="#" class="form-validate is-alter" novalidate="novalidate">
-                        <div class="form-group">
-                            <label class="form-label" for="full-name">Full Name</label>
-                            <div class="form-control-wrap">
-                                <input type="text" class="form-control" id="full-name" required="">
-                            </div>
+                    <input type="hidden" name="id_nino" value="<?php echo $id ?? 0; ?>">
+                    <input type="hidden" name="id_usuario" value="1">
+                    <div class="form-group">
+                        <label class="form-label" for="participacion">Participación</label>
+                        <div class="form-control-wrap">
+                            <input type="number" class="form-control" id="participacion" name="participacion" min="1" max="10" required>
                         </div>
-                        <div class="form-group">
-                            <label class="form-label" for="email-address">Email address</label>
-                            <div class="form-control-wrap">
-                                <input type="text" class="form-control" id="email-address" required="">
-                            </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="atencion">Atención</label>
+                        <div class="form-control-wrap">
+                            <input type="number" class="form-control" id="atencion" name="atencion" min="1" max="10" required>
                         </div>
-                        <div class="form-group">
-                            <label class="form-label" for="phone-no">Phone No</label>
-                            <div class="form-control-wrap">
-                                <input type="text" class="form-control" id="phone-no">
-                            </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="tarea_casa">Tarea en casa</label>
+                        <div class="form-control-wrap">
+                            <input type="number" class="form-control" id="tarea_casa" name="tarea_casa" min="1" max="10" required>
                         </div>
-                        <div class="form-group">
-                            <label class="form-label">Communication</label>
-                            <ul class="custom-control-group g-3 align-center">
-                                <li>
-                                    <div class="custom-control custom-control-sm custom-checkbox">
-                                        <input type="checkbox" class="custom-control-input" id="com-email">
-                                        <label class="custom-control-label" for="com-email">Email</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="custom-control custom-control-sm custom-checkbox">
-                                        <input type="checkbox" class="custom-control-input" id="com-sms">
-                                        <label class="custom-control-label" for="com-sms">SMS</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="custom-control custom-control-sm custom-checkbox">
-                                        <input type="checkbox" class="custom-control-input" id="com-phone">
-                                        <label class="custom-control-label" for="com-phone">Phone</label>
-                                    </div>
-                                </li>
-                            </ul>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="observaciones">Observaciones</label>
+                        <div class="form-control-wrap">
+                            <textarea class="form-control" id="observaciones" name="observaciones"></textarea>
                         </div>
-                        <div class="form-group">
-                            <label class="form-label" for="pay-amount">Amount</label>
-                            <div class="form-control-wrap">
-                                <input type="number" class="form-control" id="pay-amount">
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <button type="submit" class="btn btn-lg btn-primary">Save Informations</button>
-                        </div>
-                    </form>
+                    </div>
                 </div>
                 <div class="modal-footer bg-light">
-                    <span class="sub-text">Modal Footer Text</span>
+                    <button type="submit" class="btn btn-primary">Guardar</button>
                 </div>
-            </div>
+            </form>
         </div>
     </div>
+</div>

--- a/includes/modalProgreso.php
+++ b/includes/modalProgreso.php
@@ -1,0 +1,57 @@
+<div class="modal fade" id="modalProgreso" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <form method="POST" action="guardar_progreso.php" class="form-validate">
+                <div class="modal-header">
+                    <h5 class="modal-title">Nuevo progreso</h5>
+                    <a href="#" class="close" data-bs-dismiss="modal" aria-label="Close">
+                        <em class="icon ni ni-cross"></em>
+                    </a>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="id_nino" value="<?php echo $id ?? 0; ?>">
+                    <input type="hidden" name="id_usuario" value="1">
+                    <div class="form-group">
+                        <label class="form-label" for="lenguaje">Lenguaje</label>
+                        <div class="form-control-wrap">
+                            <input type="number" class="form-control" id="lenguaje" name="lenguaje" min="1" max="10" required>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="motricidad">Motricidad</label>
+                        <div class="form-control-wrap">
+                            <input type="number" class="form-control" id="motricidad" name="motricidad" min="1" max="10" required>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="atencion_pg">Atención</label>
+                        <div class="form-control-wrap">
+                            <input type="number" class="form-control" id="atencion_pg" name="atencion" min="1" max="10" required>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="memoria">Memoria</label>
+                        <div class="form-control-wrap">
+                            <input type="number" class="form-control" id="memoria" name="memoria" min="1" max="10" required>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="social">Social</label>
+                        <div class="form-control-wrap">
+                            <input type="number" class="form-control" id="social" name="social" min="1" max="10" required>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="observaciones_pg">Observaciones</label>
+                        <div class="form-control-wrap">
+                            <textarea class="form-control" id="observaciones_pg" name="observaciones"></textarea>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer bg-light">
+                    <button type="submit" class="btn btn-primary">Guardar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/pacientes/guardar_evaluacion.php
+++ b/pacientes/guardar_evaluacion.php
@@ -1,0 +1,21 @@
+<?php
+require_once '../database/conexion.php';
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$id_nino = intval($_POST['id_nino'] ?? 0);
+$id_usuario = intval($_POST['id_usuario'] ?? 0);
+$participacion = intval($_POST['participacion'] ?? 0);
+$atencion = intval($_POST['atencion'] ?? 0);
+$tarea_casa = intval($_POST['tarea_casa'] ?? 0);
+$observaciones = $_POST['observaciones'] ?? '';
+
+$stmt = $conn->prepare("INSERT INTO exp_valoraciones_sesion (id_nino, id_usuario, participacion, atencion, tarea_casa, observaciones) VALUES (?, ?, ?, ?, ?, ?)");
+$stmt->bind_param('iiiiss', $id_nino, $id_usuario, $participacion, $atencion, $tarea_casa, $observaciones);
+$stmt->execute();
+$stmt->close();
+$db->closeConnection();
+
+header('Location: paciente.php?id=' . $id_nino);
+exit();

--- a/pacientes/guardar_progreso.php
+++ b/pacientes/guardar_progreso.php
@@ -1,0 +1,23 @@
+<?php
+require_once '../database/conexion.php';
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$id_nino = intval($_POST['id_nino'] ?? 0);
+$id_usuario = intval($_POST['id_usuario'] ?? 0);
+$lenguaje = intval($_POST['lenguaje'] ?? 0);
+$motricidad = intval($_POST['motricidad'] ?? 0);
+$atencion = intval($_POST['atencion'] ?? 0);
+$memoria = intval($_POST['memoria'] ?? 0);
+$social = intval($_POST['social'] ?? 0);
+$observaciones = $_POST['observaciones'] ?? '';
+
+$stmt = $conn->prepare("INSERT INTO exp_progreso_general (id_nino, id_usuario, lenguaje, motricidad, atencion, memoria, social, observaciones) VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
+$stmt->bind_param('iiiiiiis', $id_nino, $id_usuario, $lenguaje, $motricidad, $atencion, $memoria, $social, $observaciones);
+$stmt->execute();
+$stmt->close();
+$db->closeConnection();
+
+header('Location: paciente.php?id=' . $id_nino);
+exit();

--- a/pacientes/paciente.php
+++ b/pacientes/paciente.php
@@ -26,13 +26,19 @@ date_default_timezone_set('America/Mexico_City');
     $grafica_data = [
         'primera' => null,
         'ultima' => null,
-        'promedio' => ['participacion' => 0, 'atencion' => 0, 'tarea_casa' => 0],
+        'promedio' => [
+            'lenguaje' => 0,
+            'motricidad' => 0,
+            'atencion' => 0,
+            'memoria' => 0,
+            'social' => 0,
+        ],
     ];
 
-    $sql = "SELECT participacion, atencion, tarea_casa, fecha_valoracion 
-        FROM exp_valoraciones_sesion 
+    $sql = "SELECT lenguaje, motricidad, atencion, memoria, social, fecha_registro
+        FROM exp_progreso_general
         WHERE id_nino = ?
-        ORDER BY fecha_valoracion ASC";
+        ORDER BY fecha_registro ASC";
 
     $stmt = $conn->prepare($sql);
     $stmt->bind_param('i', $id);
@@ -40,7 +46,13 @@ date_default_timezone_set('America/Mexico_City');
     $result = $stmt->get_result();
 
     $total = 0;
-    $suma = ['participacion' => 0, 'atencion' => 0, 'tarea_casa' => 0];
+    $suma = [
+        'lenguaje' => 0,
+        'motricidad' => 0,
+        'atencion' => 0,
+        'memoria' => 0,
+        'social' => 0,
+    ];
 
     while ($row = $result->fetch_assoc()) {
         if (!$grafica_data['primera']) {
@@ -48,18 +60,22 @@ date_default_timezone_set('America/Mexico_City');
         }
         $grafica_data['ultima'] = $row;
 
-        $suma['participacion'] += (int)$row['participacion'];
+        $suma['lenguaje'] += (int)$row['lenguaje'];
+        $suma['motricidad'] += (int)$row['motricidad'];
         $suma['atencion'] += (int)$row['atencion'];
-        $suma['tarea_casa'] += (int)$row['tarea_casa'];
+        $suma['memoria'] += (int)$row['memoria'];
+        $suma['social'] += (int)$row['social'];
         $total++;
     }
 
     if ($total > 0) {
         $grafica_data['promedio'] = [
-            'participacion' => round($suma['participacion'] / $total, 2),
+            'lenguaje' => round($suma['lenguaje'] / $total, 2),
+            'motricidad' => round($suma['motricidad'] / $total, 2),
             'atencion' => round($suma['atencion'] / $total, 2),
-            'tarea_casa' => round($suma['tarea_casa'] / $total, 2),
-            'fecha_valoracion' => 'Promedio'
+            'memoria' => round($suma['memoria'] / $total, 2),
+            'social' => round($suma['social'] / $total, 2),
+            'fecha_registro' => 'Promedio'
         ];
     }
 
@@ -144,6 +160,9 @@ date_default_timezone_set('America/Mexico_City');
                                     </ul>
                                     <div class="team-view">
                                         <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#modalForm">Nueva evaluación</button>
+                                    </div>
+                                    <div class="team-view mt-2">
+                                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalProgreso">Nuevo progreso</button>
                                     </div>
                                     <div class="team-view mt-4">
                                         <h6>Promedio de las últimas 15 evaluaciones</h6>
@@ -257,16 +276,18 @@ date_default_timezone_set('America/Mexico_City');
 <script>
     const datos = <?php echo json_encode($grafica_data); ?>;
 
-    const labels = ["Participación", "Atención", "Tarea en casa"];
+    const labels = ["Lenguaje", "Motricidad", "Atención", "Memoria", "Social"];
 
     const dataRadar = {
         labels: labels,
         datasets: [{
-                label: "Primera sesión (" + datos.primera.fecha_valoracion + ")",
+                label: "Primera sesión (" + datos.primera.fecha_registro + ")",
                 data: [
-                    parseFloat(datos.primera.participacion),
+                    parseFloat(datos.primera.lenguaje),
+                    parseFloat(datos.primera.motricidad),
                     parseFloat(datos.primera.atencion),
-                    parseFloat(datos.primera.tarea_casa)
+                    parseFloat(datos.primera.memoria),
+                    parseFloat(datos.primera.social)
                 ],
                 borderColor: "rgba(54, 162, 235, 1)",
                 backgroundColor: "rgba(54, 162, 235, 0.2)",
@@ -275,20 +296,24 @@ date_default_timezone_set('America/Mexico_City');
             {
                 label: "Promedio",
                 data: [
-                    parseFloat(datos.promedio.participacion),
+                    parseFloat(datos.promedio.lenguaje),
+                    parseFloat(datos.promedio.motricidad),
                     parseFloat(datos.promedio.atencion),
-                    parseFloat(datos.promedio.tarea_casa)
+                    parseFloat(datos.promedio.memoria),
+                    parseFloat(datos.promedio.social)
                 ],
                 borderColor: "rgba(75, 192, 192, 1)",
                 backgroundColor: "rgba(75, 192, 192, 0.2)",
                 fill: true
             },
             {
-                label: "Última sesión (" + datos.ultima.fecha_valoracion + ")",
+                label: "Última sesión (" + datos.ultima.fecha_registro + ")",
                 data: [
-                    parseFloat(datos.ultima.participacion),
+                    parseFloat(datos.ultima.lenguaje),
+                    parseFloat(datos.ultima.motricidad),
                     parseFloat(datos.ultima.atencion),
-                    parseFloat(datos.ultima.tarea_casa)
+                    parseFloat(datos.ultima.memoria),
+                    parseFloat(datos.ultima.social)
                 ],
                 borderColor: "rgba(255, 99, 132, 1)",
                 backgroundColor: "rgba(255, 99, 132, 0.2)",
@@ -323,6 +348,7 @@ date_default_timezone_set('America/Mexico_City');
     new Chart(document.getElementById('graficaRadar'), configRadar);
 </script>
 <?php include_once '../includes/modalEvaluacion.php'; ?>
+<?php include_once '../includes/modalProgreso.php'; ?>
 
 <?php include_once '../includes/footer.php'; ?>
 


### PR DESCRIPTION
## Summary
- implement functional modal to registrar valoraciones por sesión
- add nuevo modal para registrar progreso general
- persist evaluations and progress in new PHP handlers
- document SQL structure for new tables
- update radar chart to use exp_progreso_general

## Testing
- `php -l includes/modalEvaluacion.php`
- `php -l includes/modalProgreso.php`
- `php -l pacientes/guardar_evaluacion.php`
- `php -l pacientes/guardar_progreso.php`
- `php -l pacientes/paciente.php`
- `php -l database/queries.sql`


------
https://chatgpt.com/codex/tasks/task_e_688104a9b53c832290ed2b1eda4beba4