### PR TITLE
Add patient history modals

### DIFF
--- a/includes/modalHistorial.php
+++ b/includes/modalHistorial.php
@@ -1,0 +1,59 @@
+<div class="modal fade" id="modalHistEval" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-xl" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Historial de Evaluaciones</h5>
+                <a href="#" class="close" data-bs-dismiss="modal" aria-label="Close">
+                    <em class="icon ni ni-cross"></em>
+                </a>
+            </div>
+            <div class="modal-body">
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>Fecha</th>
+                                <th>Participación</th>
+                                <th>Atención</th>
+                                <th>Tarea en casa</th>
+                                <th>Observaciones</th>
+                            </tr>
+                        </thead>
+                        <tbody id="histEvalBody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="modalHistProg" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-xl" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Historial de Progreso</h5>
+                <a href="#" class="close" data-bs-dismiss="modal" aria-label="Close">
+                    <em class="icon ni ni-cross"></em>
+                </a>
+            </div>
+            <div class="modal-body">
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>Fecha</th>
+                                <th>Lenguaje</th>
+                                <th>Motricidad</th>
+                                <th>Atención</th>
+                                <th>Memoria</th>
+                                <th>Social</th>
+                                <th>Observaciones</th>
+                            </tr>
+                        </thead>
+                        <tbody id="histProgBody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/pacientes/get_historial.php
+++ b/pacientes/get_historial.php
@@ -1,0 +1,30 @@
+<?php
+require_once '../database/conexion.php';
+header('Content-Type: application/json');
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+$tipo = $_GET['tipo'] ?? '';
+
+$datos = [];
+
+if ($id > 0 && ($tipo === 'evaluacion' || $tipo === 'progreso')) {
+    if ($tipo === 'evaluacion') {
+        $stmt = $conn->prepare("SELECT fecha_valoracion, participacion, atencion, tarea_casa, observaciones FROM exp_valoraciones_sesion WHERE id_nino = ? ORDER BY fecha_valoracion DESC");
+    } else {
+        $stmt = $conn->prepare("SELECT fecha_registro, lenguaje, motricidad, atencion, memoria, social, observaciones FROM exp_progreso_general WHERE id_nino = ? ORDER BY fecha_registro DESC");
+    }
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result) {
+        $datos = $result->fetch_all(MYSQLI_ASSOC);
+    }
+    $stmt->close();
+}
+
+$db->closeConnection();
+
+echo json_encode($datos);


### PR DESCRIPTION
## Summary
- handle patients with no progress/evaluations
- expose API endpoint to fetch evaluation/progress history
- add modal templates for histories
- fetch history data on demand via AJAX

## Testing
- `php -l pacientes/paciente.php`
- `php -l pacientes/get_historial.php`
- `php -l includes/modalHistorial.php`


------
https://chatgpt.com/codex/tasks/task_e_6881b587dce48322b2691708a0be0c3c