### PR TITLE
Improve modal accessibility focus

### DIFF
--- a/includes/modalEvaluacion.php
+++ b/includes/modalEvaluacion.php
@@ -4,9 +4,7 @@
             <form method="POST" action="guardar_evaluacion.php" class="form-validate">
                 <div class="modal-header">
                     <h5 class="modal-title">Nueva evaluación</h5>
-                    <a href="#" class="close" data-bs-dismiss="modal" aria-label="Close">
-                        <em class="icon ni ni-cross"></em>
-                    </a>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
                 </div>
                 <div class="modal-body">
                     <input type="hidden" name="id_nino" value="<?php echo $id ?? 0; ?>">

--- a/includes/modalHistorial.php
+++ b/includes/modalHistorial.php
@@ -3,9 +3,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">Historial de Evaluaciones</h5>
-                <a href="#" class="close" data-bs-dismiss="modal" aria-label="Close">
-                    <em class="icon ni ni-cross"></em>
-                </a>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
             </div>
             <div class="modal-body">
                 <div class="table-responsive">
@@ -32,9 +30,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">Historial de Progreso</h5>
-                <a href="#" class="close" data-bs-dismiss="modal" aria-label="Close">
-                    <em class="icon ni ni-cross"></em>
-                </a>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
             </div>
             <div class="modal-body">
                 <div class="table-responsive">

--- a/includes/modalProgreso.php
+++ b/includes/modalProgreso.php
@@ -4,9 +4,7 @@
             <form method="POST" action="guardar_progreso.php" class="form-validate">
                 <div class="modal-header">
                     <h5 class="modal-title">Nuevo progreso</h5>
-                    <a href="#" class="close" data-bs-dismiss="modal" aria-label="Close">
-                        <em class="icon ni ni-cross"></em>
-                    </a>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
                 </div>
                 <div class="modal-body">
                     <input type="hidden" name="id_nino" value="<?php echo $id ?? 0; ?>">

--- a/pacientes/paciente.php
+++ b/pacientes/paciente.php
@@ -371,6 +371,7 @@ date_default_timezone_set('America/Mexico_City');
     const idPaciente = <?php echo $id; ?>;
     const btnHistEval = document.getElementById('btnHistEval');
     const btnHistProg = document.getElementById('btnHistProg');
+    let lastFocusedElement = null;
 
     function cargarHistorial(tipo, tbodyId, modalId) {
         fetch(`get_historial.php?tipo=${tipo}&id=${idPaciente}`)
@@ -390,10 +391,25 @@ date_default_timezone_set('America/Mexico_City');
                         }
                     });
                 }
-                const modal = new bootstrap.Modal(document.getElementById(modalId));
+                const modalEl = document.getElementById(modalId);
+                const modal = new bootstrap.Modal(modalEl);
+                lastFocusedElement = document.activeElement;
                 modal.show();
             });
     }
+
+    const modalHistEvalEl = document.getElementById('modalHistEval');
+    const modalHistProgEl = document.getElementById('modalHistProg');
+
+    [modalHistEvalEl, modalHistProgEl].forEach(modalEl => {
+        if (modalEl) {
+            modalEl.addEventListener('hidden.bs.modal', () => {
+                if (lastFocusedElement) {
+                    lastFocusedElement.focus();
+                }
+            });
+        }
+    });
 
     if (btnHistEval) {
         btnHistEval.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- use `btn-close` buttons in modal headers
- store focused element before opening history modals
- restore focus after closing history modals

## Testing
- `php -l pacientes/paciente.php`
- `php -l includes/modalEvaluacion.php`
- `php -l includes/modalProgreso.php`
- `php -l includes/modalHistorial.php`


------
https://chatgpt.com/codex/tasks/task_e_6881c2128d1c8322ad2373ace07dea38