### PR TITLE
Enable exam file uploads for patients

### DIFF
--- a/pacientes/paciente.php
+++ b/pacientes/paciente.php
@@ -228,6 +228,34 @@ date_default_timezone_set('America/Mexico_City');
                         <canvas id="graficaLineal" height="300"></canvas>
                     </div>
                 </div>
+
+                <div class="card mt-4">
+                    <div class="card-inner">
+                        <h5 class="title">Exámenes</h5>
+                        <form id="examUploadForm" class="mb-3">
+                            <input type="file" name="file" id="examFile" class="form-control" required>
+                            <button type="submit" class="btn btn-primary mt-2">Subir</button>
+                        </form>
+                        <div id="examFiles" class="nk-files nk-files-view-grid">
+                            <div class="nk-files-list">
+                                <?php
+                                $dir = __DIR__ . '/../uploads/exams/' . $id;
+                                if (is_dir($dir)) {
+                                    $files = array_diff(scandir($dir), ['.', '..']);
+                                    foreach ($files as $f) {
+                                        $ext = strtolower(pathinfo($f, PATHINFO_EXTENSION));
+                                        $icon = in_array($ext, ['png','jpg','jpeg','gif']) ? 'ni-file-img' : 'ni-file-pdf';
+                                        $url = '/uploads/exams/' . $id . '/' . rawurlencode($f);
+                                        echo '<div class="nk-file-item nk-file"><div class="nk-file-info"><a href="'. $url .'" class="nk-file-link" target="_blank"><div class="nk-file-title"><div class="nk-file-icon"><span class="nk-file-icon-type"><em class="icon ni '. $icon .'"></em></span></div><div class="nk-file-name"><div class="nk-file-name-text"><span class="title">'. htmlspecialchars($f) .'</span></div></div></div></a></div></div>';
+                                    }
+                                } else {
+                                    echo '<p>No hay exámenes.</p>';
+                                }
+                                ?>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -380,6 +408,7 @@ date_default_timezone_set('America/Mexico_City');
     const idPaciente = <?php echo $id; ?>;
     const btnHistEval = document.getElementById('btnHistEval');
     const btnHistProg = document.getElementById('btnHistProg');
+    const examForm = document.getElementById('examUploadForm');
     let lastFocusedElement = null;
 
     function cargarHistorial(tipo, tbodyId, modalId) {
@@ -432,6 +461,27 @@ date_default_timezone_set('America/Mexico_City');
     if (btnHistProg) {
         btnHistProg.addEventListener('click', () => {
             cargarHistorial('progreso', 'histProgBody', 'modalHistProg');
+        });
+    }
+
+    if (examForm) {
+        examForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const input = document.getElementById('examFile');
+            if (!input.files.length) return;
+            const data = new FormData();
+            data.append('file', input.files[0]);
+            data.append('id', idPaciente);
+            fetch('pacientes/upload_exam.php', { method: 'POST', body: data })
+                .then(r => r.json())
+                .then(res => {
+                    if (res.success) {
+                        Swal.fire('Archivo subido', '', 'success').then(() => location.reload());
+                    } else {
+                        Swal.fire('Error', res.message || 'Ocurrió un error', 'error');
+                    }
+                })
+                .catch(() => Swal.fire('Error', 'Ocurrió un error', 'error'));
         });
     }
 </script>

--- a/pacientes/upload_exam.php
+++ b/pacientes/upload_exam.php
@@ -1,0 +1,35 @@
+<?php
+header('Content-Type: application/json');
+
+$id = isset($_POST['id']) ? intval($_POST['id']) : 0;
+if ($id <= 0 || !isset($_FILES['file'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Datos invalidos']);
+    exit;
+}
+
+$uploadBase = __DIR__ . '/../uploads/exams/' . $id . '/';
+if (!is_dir($uploadBase)) {
+    mkdir($uploadBase, 0777, true);
+}
+
+$allowed = ['pdf', 'png', 'jpg', 'jpeg', 'gif'];
+$info = pathinfo($_FILES['file']['name']);
+$ext = strtolower($info['extension'] ?? '');
+if (!in_array($ext, $allowed)) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Tipo de archivo no permitido']);
+    exit;
+}
+
+$base = preg_replace('/[^A-Za-z0-9_-]/', '_', $info['filename']);
+$filename = $base . '_' . time() . '.' . $ext;
+$target = $uploadBase . $filename;
+
+if (move_uploaded_file($_FILES['file']['tmp_name'], $target)) {
+    echo json_encode(['success' => true, 'file' => $filename]);
+} else {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Error al guardar']);
+}
+?>


### PR DESCRIPTION
## Summary
- add backend endpoint for uploading exam files
- list exam files on patient detail page
- allow uploading PDF and images with SweetAlert success
- store uploads under `uploads/`

## Testing
- `php -l pacientes/upload_exam.php`
- `php -l pacientes/paciente.php`


------
https://chatgpt.com/codex/tasks/task_e_68855e98807c832291b4a8aceb772033