### PR TITLE
Enable exam file deletion and notes

### DIFF
--- a/pacientes/delete_exam.php
+++ b/pacientes/delete_exam.php
@@ -1,0 +1,28 @@
+<?php
+header('Content-Type: application/json');
+
+$id = isset($_POST['id']) ? intval($_POST['id']) : 0;
+$file = $_POST['file'] ?? '';
+if ($id <= 0 || !$file) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Datos invalidos']);
+    exit;
+}
+
+$dir = __DIR__ . '/../uploads/exams/' . $id . '/';
+$realDir = realpath($dir);
+$path = realpath($dir . $file);
+if (!$realDir || !$path || strpos($path, $realDir) !== 0 || !is_file($path)) {
+    http_response_code(404);
+    echo json_encode(['success' => false, 'message' => 'Archivo no encontrado']);
+    exit;
+}
+
+$notePath = $path . '.txt';
+$success = unlink($path);
+if (is_file($notePath)) {
+    unlink($notePath);
+}
+
+echo json_encode(['success' => $success]);
+?>

--- a/pacientes/paciente.php
+++ b/pacientes/paciente.php
@@ -228,6 +228,41 @@ date_default_timezone_set('America/Mexico_City');
                         <canvas id="graficaLineal" height="300"></canvas>
                     </div>
                 </div>
+
+                <div class="card mt-4">
+                    <div class="card-inner">
+                        <h5 class="title">Exámenes</h5>
+                        <form id="examUploadForm" class="mb-3">
+                            <input type="file" name="file" id="examFile" class="form-control mb-2" required>
+                            <textarea name="note" id="examNote" class="form-control mb-2" placeholder="Nota"></textarea>
+                            <button type="submit" class="btn btn-primary">Subir</button>
+                        </form>
+                        <div id="examFiles" class="nk-files nk-files-view-grid">
+                            <div class="nk-files-list">
+                                <?php
+                                $dir = __DIR__ . '/../uploads/exams/' . $id;
+                                if (is_dir($dir)) {
+                                    $files = array_diff(scandir($dir), ['.', '..']);
+                                    foreach ($files as $f) {
+                                        if (substr($f, -4) === '.txt') continue;
+                                        $ext = strtolower(pathinfo($f, PATHINFO_EXTENSION));
+                                        $icon = in_array($ext, ['png','jpg','jpeg','gif']) ? 'ni-file-img' : 'ni-file-pdf';
+                                        $url = '/uploads/exams/' . $id . '/' . rawurlencode($f);
+                                        $note = '';
+                                        $noteFile = $dir . '/' . $f . '.txt';
+                                        if (is_file($noteFile)) {
+                                            $note = '<div class="mt-1 small text-muted">Nota: '. nl2br(htmlspecialchars(trim(file_get_contents($noteFile)))) .'</div>';
+                                        }
+                                        echo '<div class="nk-file-item nk-file"><div class="nk-file-info"><a href="'. $url .'" class="nk-file-link" target="_blank"><div class="nk-file-title"><div class="nk-file-icon"><span class="nk-file-icon-type"><em class="icon ni '. $icon .'"></em></span></div><div class="nk-file-name"><div class="nk-file-name-text"><span class="title">'. htmlspecialchars($f) .'</span></div></div></div></a>'. $note .'</div><div class="nk-file-actions"><a href="#" class="btn btn-sm btn-icon btn-trigger delete-exam" data-file="'. htmlspecialchars($f) .'"><em class="icon ni ni-trash"></em></a></div></div>';
+                                    }
+                                } else {
+                                    echo '<p>No hay exámenes.</p>';
+                                }
+                                ?>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -380,6 +415,8 @@ date_default_timezone_set('America/Mexico_City');
     const idPaciente = <?php echo $id; ?>;
     const btnHistEval = document.getElementById('btnHistEval');
     const btnHistProg = document.getElementById('btnHistProg');
+    const examForm = document.getElementById('examUploadForm');
+    const examNote = document.getElementById('examNote');
     let lastFocusedElement = null;
 
     function cargarHistorial(tipo, tbodyId, modalId) {
@@ -434,6 +471,59 @@ date_default_timezone_set('America/Mexico_City');
             cargarHistorial('progreso', 'histProgBody', 'modalHistProg');
         });
     }
+
+    if (examForm) {
+        examForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const input = document.getElementById('examFile');
+            if (!input.files.length) return;
+            const data = new FormData();
+            data.append('file', input.files[0]);
+            data.append('id', idPaciente);
+            if (examNote) {
+                data.append('note', examNote.value);
+            }
+            fetch('pacientes/upload_exam.php', { method: 'POST', body: data })
+                .then(r => r.json())
+                .then(res => {
+                    if (res.success) {
+                        Swal.fire('Archivo subido', '', 'success').then(() => location.reload());
+                    } else {
+                        Swal.fire('Error', res.message || 'Ocurrió un error', 'error');
+                    }
+                })
+                .catch(() => Swal.fire('Error', 'Ocurrió un error', 'error'));
+        });
+    }
+
+    document.querySelectorAll('.delete-exam').forEach(btn => {
+        btn.addEventListener('click', function (e) {
+            e.preventDefault();
+            const file = this.getAttribute('data-file');
+            Swal.fire({
+                title: '¿Eliminar archivo?',
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonText: 'Sí, eliminar'
+            }).then(res => {
+                if (res.isConfirmed) {
+                    const fd = new FormData();
+                    fd.append('id', idPaciente);
+                    fd.append('file', file);
+                    fetch('pacientes/delete_exam.php', { method: 'POST', body: fd })
+                        .then(r => r.json())
+                        .then(resp => {
+                            if (resp.success) {
+                                Swal.fire('Eliminado', '', 'success').then(() => location.reload());
+                            } else {
+                                Swal.fire('Error', resp.message || 'Ocurrió un error', 'error');
+                            }
+                        })
+                        .catch(() => Swal.fire('Error', 'Ocurrió un error', 'error'));
+                }
+            });
+        });
+    });
 </script>
 <?php include_once '../includes/modalEvaluacion.php'; ?>
 <?php include_once '../includes/modalProgreso.php'; ?>

--- a/pacientes/upload_exam.php
+++ b/pacientes/upload_exam.php
@@ -1,0 +1,39 @@
+<?php
+header('Content-Type: application/json');
+
+$id = isset($_POST['id']) ? intval($_POST['id']) : 0;
+$note = isset($_POST['note']) ? trim($_POST['note']) : '';
+if ($id <= 0 || !isset($_FILES['file'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Datos invalidos']);
+    exit;
+}
+
+$uploadBase = __DIR__ . '/../uploads/exams/' . $id . '/';
+if (!is_dir($uploadBase)) {
+    mkdir($uploadBase, 0777, true);
+}
+
+$allowed = ['pdf', 'png', 'jpg', 'jpeg', 'gif'];
+$info = pathinfo($_FILES['file']['name']);
+$ext = strtolower($info['extension'] ?? '');
+if (!in_array($ext, $allowed)) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Tipo de archivo no permitido']);
+    exit;
+}
+
+$base = preg_replace('/[^A-Za-z0-9_-]/', '_', $info['filename']);
+$filename = $base . '_' . time() . '.' . $ext;
+$target = $uploadBase . $filename;
+
+if (move_uploaded_file($_FILES['file']['tmp_name'], $target)) {
+    if ($note !== '') {
+        file_put_contents($target . '.txt', $note);
+    }
+    echo json_encode(['success' => true, 'file' => $filename]);
+} else {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Error al guardar']);
+}
+?>


### PR DESCRIPTION
## Summary
- allow uploading notes with exam files
- display note text under each exam
- enable deleting exam files with SweetAlert confirmation

## Testing
- `php -l pacientes/paciente.php`
- `php -l pacientes/upload_exam.php`
- `php -l pacientes/delete_exam.php`


------
https://chatgpt.com/codex/tasks/task_e_68855e98807c832291b4a8aceb772033