### PR TITLE
Add endpoints for areas, sections, evaluation questions, and exam templates

### DIFF
--- a/areas/get_areas.php
+++ b/areas/get_areas.php
@@ -1,0 +1,17 @@
+<?php
+require_once '../database/conexion.php';
+header('Content-Type: application/json');
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$areas = [];
+$result = $conn->query("SELECT id_area, nombre_area, descripcion FROM exp_areas_evaluacion ORDER BY nombre_area ASC");
+if ($result) {
+    $areas = $result->fetch_all(MYSQLI_ASSOC);
+}
+
+$db->closeConnection();
+
+echo json_encode($areas);
+

--- a/database/queries.sql
+++ b/database/queries.sql
@@ -11,6 +11,12 @@ SELECT `id_area`, `nombre_area`, `descripcion` FROM `exp_areas_evaluacion` WHERE
 -- evaluaciones
 SELECT `id_evaluacion`, `id_nino`, `id_usuario`, `id_area`, `fecha`, `observaciones` FROM `exp_evaluaciones` WHERE 1;
 
+-- examenes
+SELECT `id_examen`, `id_area`, `id_usuario`, `nombre_examen`, `fecha_creacion` FROM `exp_examenes` WHERE 1;
+
+-- secciones de examen
+SELECT `id_seccion`, `id_examen`, `nombre_seccion` FROM `exp_secciones_examen` WHERE 1;
+
 -- valoraciones por sesión
 CREATE TABLE `exp_valoraciones_sesion` (
     `id_valoracion` INT AUTO_INCREMENT PRIMARY KEY,
@@ -39,4 +45,46 @@ CREATE TABLE `exp_progreso_general` (
     `fecha_registro` DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (`id_nino`) REFERENCES `nino`(`Id`),
     FOREIGN KEY (`id_usuario`) REFERENCES `Usuarios`(`id_usuario`)
+);
+
+-- examenes
+CREATE TABLE `exp_examenes` (
+    `id_examen` INT AUTO_INCREMENT PRIMARY KEY,
+    `id_area` INT NOT NULL,
+    `id_usuario` INT NOT NULL,
+    `nombre_examen` VARCHAR(255) NOT NULL,
+    `fecha_creacion` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (`id_area`) REFERENCES `exp_areas_evaluacion`(`id_area`),
+    FOREIGN KEY (`id_usuario`) REFERENCES `Usuarios`(`id_usuario`)
+);
+
+-- secciones de examen
+CREATE TABLE `exp_secciones_examen` (
+    `id_seccion` INT AUTO_INCREMENT PRIMARY KEY,
+    `id_examen` INT NOT NULL,
+    `nombre_seccion` VARCHAR(255) NOT NULL,
+    FOREIGN KEY (`id_examen`) REFERENCES `exp_examenes`(`id_examen`)
+);
+
+-- preguntas de evaluacion
+CREATE TABLE `exp_preguntas_evaluacion` (
+    `id_pregunta` INT AUTO_INCREMENT PRIMARY KEY,
+    `id_seccion` INT NOT NULL,
+    `pregunta` TEXT NOT NULL,
+    FOREIGN KEY (`id_seccion`) REFERENCES `exp_secciones_examen`(`id_seccion`)
+);
+
+-- opciones disponibles para preguntas
+CREATE TABLE `exp_opciones_pregunta` (
+    `id_opcion` INT AUTO_INCREMENT PRIMARY KEY,
+    `texto` VARCHAR(255) NOT NULL
+);
+
+-- relacion muchas-a-muchas entre preguntas y opciones
+CREATE TABLE `exp_pregunta_opcion` (
+    `id_pregunta` INT NOT NULL,
+    `id_opcion` INT NOT NULL,
+    PRIMARY KEY (`id_pregunta`, `id_opcion`),
+    FOREIGN KEY (`id_pregunta`) REFERENCES `exp_preguntas_evaluacion`(`id_pregunta`),
+    FOREIGN KEY (`id_opcion`) REFERENCES `exp_opciones_pregunta`(`id_opcion`)
 );

--- a/examenes/insert.php
+++ b/examenes/insert.php
@@ -1,0 +1,29 @@
+<?php
+require_once '../database/conexion.php';
+header('Content-Type: application/json');
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$data = json_decode(file_get_contents('php://input'), true);
+
+$id_area = isset($data['id_area']) ? intval($data['id_area']) : 0;
+$id_usuario = isset($data['id_usuario']) ? intval($data['id_usuario']) : 0;
+$nombre_examen = $data['nombre_examen'] ?? '';
+
+$response = ['success' => false];
+
+if ($id_area && $id_usuario && $nombre_examen) {
+    $stmt = $conn->prepare('INSERT INTO exp_examenes (id_area, id_usuario, nombre_examen) VALUES (?, ?, ?)');
+    $stmt->bind_param('iis', $id_area, $id_usuario, $nombre_examen);
+    if ($stmt->execute()) {
+        $response['success'] = true;
+        $response['id_examen'] = $stmt->insert_id;
+    } else {
+        $response['error'] = $conn->error;
+    }
+    $stmt->close();
+}
+
+$db->closeConnection();
+echo json_encode($response);

--- a/preguntas/insert.php
+++ b/preguntas/insert.php
@@ -1,0 +1,42 @@
+<?php
+require_once '../database/conexion.php';
+header('Content-Type: application/json');
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$data = json_decode(file_get_contents('php://input'), true);
+
+$pregunta = $data['pregunta'] ?? '';
+$id_seccion = isset($data['id_seccion']) ? intval($data['id_seccion']) : 0;
+$opciones = $data['opciones'] ?? [];
+
+$response = ['success' => false];
+
+if ($pregunta && $id_seccion) {
+    $stmt = $conn->prepare('INSERT INTO exp_preguntas_evaluacion (pregunta, id_seccion) VALUES (?, ?)');
+    $stmt->bind_param('si', $pregunta, $id_seccion);
+    if ($stmt->execute()) {
+        $id_pregunta = $stmt->insert_id;
+        $stmt->close();
+
+        if (!empty($opciones)) {
+            $stmtRel = $conn->prepare('INSERT INTO exp_pregunta_opcion (id_pregunta, id_opcion) VALUES (?, ?)');
+            foreach ($opciones as $id_opcion) {
+                $id_opcion = intval($id_opcion);
+                $stmtRel->bind_param('ii', $id_pregunta, $id_opcion);
+                $stmtRel->execute();
+            }
+            $stmtRel->close();
+        }
+
+        $response['success'] = true;
+        $response['id_pregunta'] = $id_pregunta;
+    } else {
+        $response['error'] = $conn->error;
+        $stmt->close();
+    }
+}
+
+$db->closeConnection();
+echo json_encode($response);

--- a/secciones/insert.php
+++ b/secciones/insert.php
@@ -1,0 +1,28 @@
+<?php
+require_once '../database/conexion.php';
+header('Content-Type: application/json');
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$data = json_decode(file_get_contents('php://input'), true);
+
+$id_examen = isset($data['id_examen']) ? intval($data['id_examen']) : 0;
+$nombre_seccion = $data['nombre_seccion'] ?? '';
+
+$response = ['success' => false];
+
+if ($id_examen && $nombre_seccion) {
+    $stmt = $conn->prepare('INSERT INTO exp_secciones_examen (id_examen, nombre_seccion) VALUES (?, ?)');
+    $stmt->bind_param('is', $id_examen, $nombre_seccion);
+    if ($stmt->execute()) {
+        $response['success'] = true;
+        $response['id_seccion'] = $stmt->insert_id;
+    } else {
+        $response['error'] = $conn->error;
+    }
+    $stmt->close();
+}
+
+$db->closeConnection();
+echo json_encode($response);


### PR DESCRIPTION
## Summary
- introduce `exp_examenes` table to link exams with areas and their creators, and reference it from exam sections
- update `secciones/insert.php` to attach sections to a specific exam
- add `examenes/insert.php` endpoint for creating new exams

## Testing
- `php -l secciones/insert.php`
- `php -l examenes/insert.php`


------
https://chatgpt.com/codex/tasks/task_e_6894e09df5408322af63fba7edd3aeb5