### PR TITLE
Fix broken links after removing base tag

### DIFF
--- a/Sessiones.php
+++ b/Sessiones.php
@@ -43,7 +43,7 @@
             <td>10:00 AM</td>
             <td>Lenguaje</td>
             <td>
-              <a href="Perfil.php" class="btn btn-sm btn-success">Perfil</a>
+              <a href="/Perfil.php" class="btn btn-sm btn-success">Perfil</a>
             </td>
           </tr>
           <tr>
@@ -54,7 +54,7 @@
             <td>11:30 AM</td>
             <td>Psicología</td>
             <td>
-              <a href="Perfil.php" class="btn btn-sm btn-success">Perfil</a>
+              <a href="/Perfil.php" class="btn btn-sm btn-success">Perfil</a>
 
             </td>
           </tr>

--- a/includes/menu_superior.php
+++ b/includes/menu_superior.php
@@ -37,7 +37,7 @@
                                             <div class="dropdown-body">
                                                 <ul class="chat-list">
                                                     <li class="chat-item">
-                                                        <a class="chat-link" href="html/apps-chats.html">
+                                                        <a class="chat-link" href="/html/apps-chats.html">
                                                             <div class="chat-media user-avatar">
                                                                 <span>IH</span>
                                                                 <span class="status dot dot-lg dot-gray"></span>
@@ -57,7 +57,7 @@
                                                         </a>
                                                     </li><!-- .chat-item -->
                                                     <li class="chat-item is-unread">
-                                                        <a class="chat-link" href="html/apps-chats.html">
+                                                        <a class="chat-link" href="/html/apps-chats.html">
                                                             <div class="chat-media user-avatar bg-pink">
                                                                 <span>AB</span>
                                                                 <span class="status dot dot-lg dot-success"></span>
@@ -77,7 +77,7 @@
                                                         </a>
                                                     </li><!-- .chat-item -->
                                                     <li class="chat-item">
-                                                        <a class="chat-link" href="html/apps-chats.html">
+                                                        <a class="chat-link" href="/html/apps-chats.html">
                                                             <div class="chat-media user-avatar">
                                                                 <img src="/images/avatar/b-sm.jpg" alt="">
                                                             </div>
@@ -93,7 +93,7 @@
                                                         </a>
                                                     </li><!-- .chat-item -->
                                                     <li class="chat-item">
-                                                        <a class="chat-link" href="html/apps-chats.html">
+                                                        <a class="chat-link" href="/html/apps-chats.html">
                                                             <div class="chat-media user-avatar user-avatar-multiple">
                                                                 <div class="user-avatar">
                                                                     <img src="/images/avatar/c-sm.jpg" alt="">
@@ -117,7 +117,7 @@
                                                         </a>
                                                     </li><!-- .chat-item -->
                                                     <li class="chat-item">
-                                                        <a class="chat-link" href="html/apps-chats.html">
+                                                        <a class="chat-link" href="/html/apps-chats.html">
                                                             <div class="chat-media user-avatar">
                                                                 <img src="/images/avatar/a-sm.jpg" alt="">
                                                                 <span class="status dot dot-lg dot-success"></span>
@@ -134,7 +134,7 @@
                                                         </a>
                                                     </li><!-- .chat-item -->
                                                     <li class="chat-item">
-                                                        <a class="chat-link" href="html/apps-chats.html">
+                                                        <a class="chat-link" href="/html/apps-chats.html">
                                                             <div class="chat-media user-avatar bg-purple">
                                                                 <span>TW</span>
                                                             </div>
@@ -155,7 +155,7 @@
                                                 </ul><!-- .chat-list -->
                                             </div><!-- .nk-dropdown-body -->
                                             <div class="dropdown-foot center">
-                                                <a href="html/apps-chats.html">View All</a>
+                                                <a href="/html/apps-chats.html">View All</a>
                                             </div>
                                         </div>
                                     </li>
@@ -242,9 +242,9 @@
                                             </div>
                                             <div class="dropdown-inner">
                                                 <ul class="link-list">
-                                                    <li><a href="html/user-profile-regular.html"><em class="icon ni ni-user-alt"></em><span>View Profile</span></a></li>
-                                                    <li><a href="html/user-profile-setting.html"><em class="icon ni ni-setting-alt"></em><span>Account Setting</span></a></li>
-                                                    <li><a href="html/user-profile-activity.html"><em class="icon ni ni-activity-alt"></em><span>Login Activity</span></a></li>
+                                                    <li><a href="/html/user-profile-regular.html"><em class="icon ni ni-user-alt"></em><span>View Profile</span></a></li>
+                                                    <li><a href="/html/user-profile-setting.html"><em class="icon ni ni-setting-alt"></em><span>Account Setting</span></a></li>
+                                                    <li><a href="/html/user-profile-activity.html"><em class="icon ni ni-activity-alt"></em><span>Login Activity</span></a></li>
                                                     <li><a class="dark-switch" href="#"><em class="icon ni ni-moon"></em><span>Dark Mode</span></a></li>
                                                 </ul>
                                             </div> 

--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -25,7 +25,7 @@ function isActive($page) {
                                     <h6 class="overline-title text-primary-alt ">Início</h6>
                                 </li><!-- .nk-menu-item -->
                                 <li class="nk-menu-item" id="menu-casa">
-                                    <a href="index.php" class="nk-menu-link ">
+                                    <a href="/index.php" class="nk-menu-link ">
                                         <span class="nk-menu-icon"><em class="icon ni ni-home"></em></span>
                                         <span class="nk-menu-text">Casa</span>
                                     </a>
@@ -67,13 +67,13 @@ function isActive($page) {
                                     </a>
                                     <ul class="nk-menu-sub">
                                         <li class="nk-menu-item">
-                                            <a href="html/index-profile.html" class="nk-menu-link"><span class="nk-menu-text">Perfil</span></a>
+                                            <a href="/html/index-profile.html" class="nk-menu-link"><span class="nk-menu-text">Perfil</span></a>
                                         </li><!-- .nk-menu-item -->
                                         <li class="nk-menu-item">
-                                            <a href="html/index-profile-activity.html" class="nk-menu-link"><span class="nk-menu-text">Configuración</span></a>
+                                            <a href="/html/index-profile-activity.html" class="nk-menu-link"><span class="nk-menu-text">Configuración</span></a>
                                         </li><!-- .nk-menu-item -->
                                         <li class="nk-menu-item">
-                                            <a href="html/index-profile-settings.html" class="nk-menu-link"><span class="nk-menu-text">
+                                            <a href="/html/index-profile-settings.html" class="nk-menu-link"><span class="nk-menu-text">
                                                 Salir
                                             </span></a>
                                         </li><!-- .nk-menu-item -->

--- a/login.php
+++ b/login.php
@@ -37,18 +37,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <html lang="zxx" class="js">
 
 <head>
-    <base href="../../../">
     <meta charset="utf-8">
     <meta name="author" content="JERS">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="A powerful and conceptual apps base dashboard template that especially build for developers and programmers.">
     <!-- Fav Icon  -->
-    <link rel="shortcut icon" href="./images/favicon.png">
+    <link rel="shortcut icon" href="/images/favicon.png">
     <!-- Page Title  -->
     <title>Login | DashLite Admin Template</title>
     <!-- StyleSheets  -->
-    <link rel="stylesheet" href="./assets/css/dashlite.css?ver=3.3.0">
-    <link id="skin-default" rel="stylesheet" href="./assets/css/theme.css?ver=3.3.0">
+    <link rel="stylesheet" href="/assets/css/dashlite.css?ver=3.3.0">
+    <link id="skin-default" rel="stylesheet" href="/assets/css/theme.css?ver=3.3.0">
 </head>
 
 <body class="nk-body ui-rounder npc-general pg-auth">
@@ -63,9 +62,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         <div class="nk-split-content nk-block-area nk-block-area-column nk-auth-container bg-white">
                             <div class="nk-block nk-block-middle nk-auth-body">
                                 <div class="brand-logo pb-5">
-                                    <a href="html/index.html" class="logo-link">
-                                        <img class="logo-light logo-img logo-img-lg" src="./images/logo.png" srcset="./images/logo2x.png 2x" alt="logo">
-                                        <img class="logo-dark logo-img logo-img-lg" src="./images/logo-dark.png" srcset="./images/logo-dark2x.png 2x" alt="logo-dark">
+                                    <a href="/html/index.html" class="logo-link">
+                                        <img class="logo-light logo-img logo-img-lg" src="/images/logo.png" srcset="/images/logo2x.png 2x" alt="logo">
+                                        <img class="logo-dark logo-img logo-img-lg" src="/images/logo-dark.png" srcset="/images/logo-dark2x.png 2x" alt="logo-dark">
                                     </a>
                                 </div>
                                 <div class="nk-block-head">
@@ -81,7 +80,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                         <?php echo $error; ?>
                                     </div>
                                 <?php endif; ?>
-                                <form action="login.php" method="POST">
+                                <form action="/login.php" method="POST">
                                     <div class="form-group">
                                         <div class="form-label-group">
                                             <label class="form-label" for="default-01">Correo electrónico o usuario</label>
@@ -128,8 +127,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </div>
     <!-- app-root @e -->
     <!-- JavaScript -->
-    <script src="./assets/js/bundle.js?ver=3.3.0"></script>
-    <script src="./assets/js/scripts.js?ver=3.3.0"></script>
+    <script src="/assets/js/bundle.js?ver=3.3.0"></script>
+    <script src="/assets/js/scripts.js?ver=3.3.0"></script>
     <!-- select region modal -->
     <div class="modal fade" tabindex="-1" role="dialog" id="region">
         <div class="modal-dialog modal-lg" role="document">

--- a/pacientes/index.php
+++ b/pacientes/index.php
@@ -61,7 +61,7 @@ include_once '../includes/head.php';
                                                     </div>
                                                     <div class="nk-tb-col tb-col-sm">
                                                         <span class="tb-product">
-                                                            <img src="./images/product/a.png" alt="" class="thumb">
+                                                            <img src="/images/product/a.png" alt="" class="thumb">
                                                             <span class="title">Pink Fitness Tracker</span>
                                                         </span>
                                                     </div>

--- a/pacientes/paciente.php
+++ b/pacientes/paciente.php
@@ -199,7 +199,7 @@ date_default_timezone_set('America/Mexico_City');
                                         </div>
 
                                         <div class="team-view mt-2">
-                                            <a href="./pacientes/reporte_paciente.php?id=<?php echo $id; ?>" class="btn btn-outline-success">Descargar reporte</a>
+                                            <a href="/pacientes/reporte_paciente.php?id=<?php echo $id; ?>" class="btn btn-outline-success">Descargar reporte</a>
                                         </div>
 
                                     </div>


### PR DESCRIPTION
## Summary
- use absolute paths in sidebar navigation and top menu
- update patient pages with correct asset and report URLs
- remove base tag from login and switch assets to absolute paths

## Testing
- `php -l includes/navigation.php`
- `php -l includes/menu_superior.php`
- `php -l pacientes/index.php`
- `php -l pacientes/paciente.php`
- `php -l login.php`
- `php -l Sessiones.php`


------
https://chatgpt.com/codex/tasks/task_e_689925ad23ec832282b1eff5786db906