### PR TITLE
Agregar evaluaciones de examen por paciente

### DIFF
--- a/database/queries.sql
+++ b/database/queries.sql
@@ -88,3 +88,16 @@ CREATE TABLE `exp_pregunta_opcion` (
     FOREIGN KEY (`id_pregunta`) REFERENCES `exp_preguntas_evaluacion`(`id_pregunta`),
     FOREIGN KEY (`id_opcion`) REFERENCES `exp_opciones_pregunta`(`id_opcion`)
 );
+
+-- evaluacion de examen aplicada
+CREATE TABLE `exp_evaluacion_examen` (
+    `id_eval` INT AUTO_INCREMENT PRIMARY KEY,
+    `id_examen` INT NOT NULL,
+    `id_nino` INT NOT NULL,
+    `id_usuario` INT NOT NULL,
+    `respuestas` TEXT NOT NULL,
+    `fecha` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (`id_examen`) REFERENCES `exp_examenes`(`id_examen`),
+    FOREIGN KEY (`id_nino`) REFERENCES `nino`(`Id`),
+    FOREIGN KEY (`id_usuario`) REFERENCES `Usuarios`(`id`)
+);

--- a/pacientes/evaluacion_examen.php
+++ b/pacientes/evaluacion_examen.php
@@ -1,0 +1,130 @@
+<?php
+include_once '../includes/head.php';
+include_once '../includes/menu_superior.php';
+require_once '../database/conexion.php';
+
+$id_nino = isset($_GET['id']) ? intval($_GET['id']) : 0;
+$id_examen = isset($_GET['examen']) ? intval($_GET['examen']) : 0;
+
+$db = new Database();
+$conn = $db->getConnection();
+?>
+<div class="nk-wrap ">
+    <div class="nk-content nk-content-fluid">
+        <div class="container-xl wide-xl">
+            <div class="nk-content-body">
+<?php
+if ($id_examen === 0) {
+    $examenes = [];
+    $res = $conn->query("SELECT id_examen, nombre_examen FROM exp_examenes ORDER BY nombre_examen ASC");
+    if ($res) {
+        $examenes = $res->fetch_all(MYSQLI_ASSOC);
+    }
+    echo '<h3 class="nk-block-title page-title mb-4">Selecciona evaluación</h3>';
+    if (!empty($examenes)) {
+        echo '<div class="row g-gs">';
+        foreach ($examenes as $ex) {
+            echo '<div class="col-md-6">';
+            echo '<div class="card card-full">';
+            echo '<div class="card-inner d-flex justify-content-between align-items-center">';
+            echo '<div>' . htmlspecialchars($ex['nombre_examen']) . '</div>';
+            echo '<a class="btn btn-primary btn-sm" href="evaluacion_examen.php?id=' . $id_nino . '&examen=' . $ex['id_examen'] . '">Iniciar</a>';
+            echo '</div></div></div>';
+        }
+        echo '</div>';
+    } else {
+        echo '<p>No hay evaluaciones disponibles.</p>';
+    }
+} else {
+    $exam_name = '';
+    $stmt = $conn->prepare("SELECT nombre_examen FROM exp_examenes WHERE id_examen=? LIMIT 1");
+    $stmt->bind_param('i', $id_examen);
+    $stmt->execute();
+    $stmt->bind_result($exam_name);
+    $stmt->fetch();
+    $stmt->close();
+
+    $sections = [];
+    $stmt = $conn->prepare("SELECT id_seccion, nombre_seccion FROM exp_secciones_examen WHERE id_examen=? ORDER BY id_seccion ASC");
+    $stmt->bind_param('i', $id_examen);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if ($res) {
+        $sections = $res->fetch_all(MYSQLI_ASSOC);
+        foreach ($sections as &$s) {
+            $stmtQ = $conn->prepare("SELECT id_pregunta, pregunta FROM exp_preguntas_evaluacion WHERE id_seccion=? ORDER BY id_pregunta ASC");
+            $stmtQ->bind_param('i', $s['id_seccion']);
+            $stmtQ->execute();
+            $resQ = $stmtQ->get_result();
+            $s['preguntas'] = $resQ ? $resQ->fetch_all(MYSQLI_ASSOC) : [];
+            foreach ($s['preguntas'] as &$p) {
+                $stmtO = $conn->prepare("SELECT op.texto FROM exp_pregunta_opcion po JOIN exp_opciones_pregunta op ON po.id_opcion=op.id_opcion WHERE po.id_pregunta=? ORDER BY op.texto ASC");
+                $stmtO->bind_param('i', $p['id_pregunta']);
+                $stmtO->execute();
+                $resO = $stmtO->get_result();
+                $p['opciones'] = $resO ? $resO->fetch_all(MYSQLI_ASSOC) : [];
+                $stmtO->close();
+            }
+            unset($p);
+            $stmtQ->close();
+        }
+        unset($s);
+    }
+    $stmt->close();
+
+    echo '<h3 class="nk-block-title page-title mb-4">' . htmlspecialchars($exam_name) . '</h3>';
+    echo '<form id="evalForm" method="POST" action="guardar_examen_evaluacion.php">';
+    echo '<input type="hidden" name="id_nino" value="' . $id_nino . '">';
+    echo '<input type="hidden" name="id_examen" value="' . $id_examen . '">';
+    echo '<input type="hidden" name="respuestas" id="respuestas">';
+    $secIndex = 1;
+    $totalSections = count($sections);
+    foreach ($sections as $section) {
+        $display = ($secIndex === 1) ? '' : 'style="display:none;"';
+        echo '<div id="sec' . $secIndex . '" ' . $display . '>';
+        echo '<h5 class="mb-3">' . htmlspecialchars($section['nombre_seccion']) . '</h5>';
+        foreach ($section['preguntas'] as $q) {
+            $qid = 'q' . $q['id_pregunta'];
+            echo '<div class="form-group">';
+            echo '<label class="form-label">' . htmlspecialchars($q['pregunta']) . '</label>';
+            echo '<select class="form-select" id="' . $qid . '" data-pregunta="' . htmlspecialchars($q['pregunta']) . '" required>';
+            echo '<option value="">Selecciona</option>';
+            if (!empty($q['opciones'])) {
+                foreach ($q['opciones'] as $op) {
+                    echo '<option value="' . htmlspecialchars($op['texto']) . '">' . htmlspecialchars($op['texto']) . '</option>';
+                }
+            } else {
+                echo '<option value="Si">Sí</option><option value="Parcial">Parcial</option><option value="No">No</option>';
+            }
+            echo '</select>';
+            echo '<textarea id="' . $qid . 'c" class="form-control mt-2" placeholder="Comentario"></textarea>';
+            echo '</div>';
+        }
+        echo '<div class="mt-3">';
+        if ($secIndex > 1) {
+            echo '<button type="button" class="btn btn-secondary me-2" onclick="prevSec(' . $secIndex . ')">Anterior</button>';
+        }
+        if ($secIndex < $totalSections) {
+            echo '<button type="button" class="btn btn-primary" onclick="nextSec(' . $secIndex . ')">Siguiente</button>';
+        } else {
+            echo '<button type="submit" class="btn btn-success">Guardar</button>';
+        }
+        echo '</div>';
+        echo '</div>';
+        $secIndex++;
+    }
+    echo '</form>';
+}
+$db->closeConnection();
+?>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+function nextSec(n){document.getElementById('sec'+n).style.display='none';document.getElementById('sec'+(n+1)).style.display='block';}
+function prevSec(n){document.getElementById('sec'+n).style.display='none';document.getElementById('sec'+(n-1)).style.display='block';}
+const form=document.getElementById('evalForm');
+if(form){form.addEventListener('submit',function(e){const data=[];document.querySelectorAll('[data-pregunta]').forEach(sel=>{const id=sel.id;data.push({pregunta:sel.getAttribute('data-pregunta'),respuesta:sel.value,comentario:document.getElementById(id+'c').value});});document.getElementById('respuestas').value=JSON.stringify(data);});}
+</script>
+<?php include_once '../includes/footer.php'; ?>

--- a/pacientes/guardar_examen_evaluacion.php
+++ b/pacientes/guardar_examen_evaluacion.php
@@ -1,0 +1,21 @@
+<?php
+require_once '../database/conexion.php';
+session_start();
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$id_nino = intval($_POST['id_nino'] ?? 0);
+$id_examen = intval($_POST['id_examen'] ?? 0);
+$id_usuario = intval($_SESSION['id'] ?? 0);
+$respuestas = $_POST['respuestas'] ?? '';
+
+$stmt = $conn->prepare("INSERT INTO exp_evaluacion_examen (id_examen, id_nino, id_usuario, respuestas) VALUES (?, ?, ?, ?)");
+$stmt->bind_param('iiis', $id_examen, $id_nino, $id_usuario, $respuestas);
+$stmt->execute();
+$stmt->close();
+$db->closeConnection();
+
+header('Location: paciente.php?id=' . $id_nino);
+exit();
+?>

--- a/pacientes/paciente.php
+++ b/pacientes/paciente.php
@@ -22,6 +22,7 @@ date_default_timezone_set('America/Mexico_City');
 
     $citas  = $conn->query("SELECT COUNT(*) as total FROM Cita WHERE IdNino = $id")->fetch_assoc()['total'] ?? 0;
     $evaluaciones  = $conn->query("SELECT COUNT(*) as total FROM exp_valoraciones_sesion WHERE id_nino = $id")->fetch_assoc()['total'] ?? 0;
+    $examenes = $conn->query("SELECT COUNT(*) as total FROM exp_evaluacion_examen WHERE id_nino = $id")->fetch_assoc()['total'] ?? 0;
 
     $grafica_data = [
         'primera' => null,
@@ -118,6 +119,16 @@ date_default_timezone_set('America/Mexico_City');
 
     // Ordenar por fecha ascendente para que se grafique cronológicamente
     $ultimas_evaluaciones = array_reverse($ultimas_evaluaciones);
+
+    $lista_examenes = [];
+    $stmt = $conn->prepare("SELECT ee.id_eval, ee.fecha, u.name AS usuario, ex.nombre_examen FROM exp_evaluacion_examen ee JOIN Usuarios u ON ee.id_usuario = u.id JOIN exp_examenes ex ON ee.id_examen = ex.id_examen WHERE ee.id_nino = ? ORDER BY ee.fecha DESC");
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result) {
+        $lista_examenes = $result->fetch_all(MYSQLI_ASSOC);
+    }
+
     $db->closeConnection();
     ?>
     <div class="nk-content nk-content-fluid">
@@ -166,10 +177,11 @@ date_default_timezone_set('America/Mexico_City');
                                     <ul class="team-statistics">
                                         <li><span><?php echo $citas; ?></span><span>Sesiones</span></li>
                                         <li><span><?php echo $evaluaciones; ?></span><span>Evaluaciones</span></li>
-                                        <li><span>0</span><span>Exámenes</span></li>
+                                        <li><span><?php echo $examenes; ?></span><span>Exámenes</span></li>
                                     </ul>
                                     <div class="team-view">
-                                        <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#modalForm">Nueva evaluación</button>
+                                        <button type="button" class="btn btn-success me-2" data-bs-toggle="modal" data-bs-target="#modalForm">Nueva evaluación</button>
+                                        <a href="evaluacion_examen.php?id=<?php echo $id; ?>" class="btn btn-warning">Agregar examen</a>
                                     </div>
 
                                     <div class="team-view mt-4">
@@ -305,6 +317,29 @@ date_default_timezone_set('America/Mexico_City');
                             </div>
                         </div>
                     </div>
+                </div>
+            </div>
+            <div class="card mt-4">
+                <div class="card-inner">
+                    <h5 class="title mb-3">Evaluaciones de examen</h5>
+                    <table class="table table-striped">
+                        <thead>
+                            <tr><th>Fecha</th><th>Evaluación</th><th>Usuario</th><th>PDF</th></tr>
+                        </thead>
+                        <tbody>
+                        <?php foreach ($lista_examenes as $ex): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($ex['fecha']); ?></td>
+                                <td><?php echo htmlspecialchars($ex['nombre_examen']); ?></td>
+                                <td><?php echo htmlspecialchars($ex['usuario']); ?></td>
+                                <td><a class="btn btn-sm btn-primary" target="_blank" href="pdf_evaluacion_examen.php?id=<?php echo $ex['id_eval']; ?>">Descargar</a></td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (empty($lista_examenes)): ?>
+                            <tr><td colspan="4">Sin evaluaciones</td></tr>
+                        <?php endif; ?>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>

--- a/pacientes/pdf_evaluacion_examen.php
+++ b/pacientes/pdf_evaluacion_examen.php
@@ -1,0 +1,44 @@
+<?php
+require_once '../database/conexion.php';
+require_once '../lib/SimplePDF.php';
+
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+$db = new Database();
+$conn = $db->getConnection();
+
+$stmt = $conn->prepare("SELECT ee.respuestas, ee.fecha, n.name AS paciente, u.name AS usuario, ex.nombre_examen FROM exp_evaluacion_examen ee JOIN nino n ON ee.id_nino=n.Id JOIN Usuarios u ON ee.id_usuario=u.id JOIN exp_examenes ex ON ee.id_examen = ex.id_examen WHERE ee.id_eval=? LIMIT 1");
+$stmt->bind_param('i',$id);
+$stmt->execute();
+$res = $stmt->get_result();
+$eval = $res ? $res->fetch_assoc() : null;
+$stmt->close();
+$db->closeConnection();
+
+if(!$eval){
+    die('Evaluación no encontrada');
+}
+
+$resp = json_decode($eval['respuestas'], true) ?: [];
+$pdf = new SimplePDF();
+$pdf->addPage();
+$pdf->text(40,40,'Evaluación: '.$eval['nombre_examen']);
+$pdf->text(40,60,'Paciente: '.$eval['paciente']);
+$pdf->text(40,80,'Fecha: '.$eval['fecha']);
+$pdf->text(40,100,'Aplicó: '.$eval['usuario']);
+$y = 130;
+$i=1;
+foreach($resp as $r){
+    $pdf->text(40,$y,$i.'. '.$r['pregunta']);
+    $y+=20;
+    $pdf->text(60,$y,'Respuesta: '.$r['respuesta']);
+    $y+=20;
+    if(!empty($r['comentario'])){
+        $pdf->text(60,$y,'Comentario: '.$r['comentario']);
+        $y+=20;
+    }
+    $y+=10;
+    $i++;
+}
+header('Content-Type: application/pdf');
+echo $pdf->output();
+?>


### PR DESCRIPTION
## Summary
- Listar las evaluaciones disponibles antes de aplicar un examen y mostrar sus secciones de forma dinámica.
- Guardar el identificador de examen y mostrar el nombre de la evaluación en el perfil del paciente y en el PDF generado.
- Actualizar el esquema `exp_evaluacion_examen` para relacionarlo con los exámenes definidos.

## Testing
- `php -l pacientes/evaluacion_examen.php`
- `php -l pacientes/guardar_examen_evaluacion.php`
- `php -l pacientes/paciente.php`
- `php -l pacientes/pdf_evaluacion_examen.php`


------
https://chatgpt.com/codex/tasks/task_e_689d0bb44d4883229327229e7ceb0df2