### PR TITLE
Permitir edición, guardado y finalización de evaluaciones

### DIFF
--- a/database/queries.sql
+++ b/database/queries.sql
@@ -96,6 +96,7 @@ CREATE TABLE `exp_evaluacion_examen` (
     `id_nino` INT NOT NULL,
     `id_usuario` INT NOT NULL,
     `respuestas` TEXT NOT NULL,
+    `status` TINYINT DEFAULT 0,
     `fecha` DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (`id_examen`) REFERENCES `exp_examenes`(`id_examen`),
     FOREIGN KEY (`id_nino`) REFERENCES `nino`(`Id`),

--- a/pacientes/guardar_examen_evaluacion.php
+++ b/pacientes/guardar_examen_evaluacion.php
@@ -6,18 +6,40 @@ $db = new Database();
 $conn = $db->getConnection();
 
 $id_nino = intval($_POST['id_nino'] ?? 0);
-
 $id_examen = intval($_POST['id_examen'] ?? 0);
+$id_eval = intval($_POST['id_eval'] ?? 0);
 $id_usuario = intval($_SESSION['id'] ?? 0);
 $respuestas = $_POST['respuestas'] ?? '';
+$status = intval($_POST['status'] ?? 0);
+$autosave = isset($_POST['autosave']);
 
-$stmt = $conn->prepare("INSERT INTO exp_evaluacion_examen (id_examen, id_nino, id_usuario, respuestas) VALUES (?, ?, ?, ?)");
-$stmt->bind_param('iiis', $id_examen, $id_nino, $id_usuario, $respuestas);
+if ($id_eval > 0) {
+    if ($status === 1) {
+        $stmt = $conn->prepare("UPDATE exp_evaluacion_examen SET respuestas=?, id_usuario=?, status=1 WHERE id_eval=? AND id_examen=? AND id_nino=? AND status=0");
+        $stmt->bind_param('siiii', $respuestas, $id_usuario, $id_eval, $id_examen, $id_nino);
+        $stmt->execute();
+        $stmt->close();
+    } else {
+        $stmt = $conn->prepare("UPDATE exp_evaluacion_examen SET respuestas=?, id_usuario=? WHERE id_eval=? AND id_examen=? AND id_nino=? AND status=0");
+        $stmt->bind_param('siiii', $respuestas, $id_usuario, $id_eval, $id_examen, $id_nino);
+        $stmt->execute();
+        $stmt->close();
+    }
+} else {
+    $stmt = $conn->prepare("INSERT INTO exp_evaluacion_examen (id_examen, id_nino, id_usuario, respuestas, status) VALUES (?, ?, ?, ?, ?)");
+    $stmt->bind_param('iiisi', $id_examen, $id_nino, $id_usuario, $respuestas, $status);
+    $stmt->execute();
+    $id_eval = $conn->insert_id;
+    $stmt->close();
+}
 
-$stmt->execute();
-$stmt->close();
 $db->closeConnection();
 
-header('Location: paciente.php?id=' . $id_nino);
+if ($autosave) {
+    header('Content-Type: application/json');
+    echo json_encode(['success' => true, 'id_eval' => $id_eval]);
+} else {
+    header('Location: paciente.php?id=' . $id_nino);
+}
 exit();
 ?>


### PR DESCRIPTION
## Resumen
- Se agrega campo de estado para las evaluaciones realizadas
- Se muestra botón **Finalizar** que marca la evaluación como cerrada y bloquea nuevas ediciones
- El listado de exámenes indica si una evaluación está en progreso o finalizada

## Testing
- `php -l pacientes/evaluacion_examen.php`
- `php -l pacientes/guardar_examen_evaluacion.php`


------
https://chatgpt.com/codex/tasks/task_e_689e81e6593483229a1f7651258c0ef8