### PR TITLE
Add photo-based evaluation upload

### DIFF
--- a/evaluaciones.php
+++ b/evaluaciones.php
@@ -35,6 +35,9 @@ date_default_timezone_set('America/Mexico_City');
                                             <p>Listado de evaluaciones realizadas.</p>
                                         </div>
                                     </div><!-- .nk-block-head-content -->
+                                    <div class="nk-block-head-content">
+                                        <a href="subir_evaluacion.php" class="btn btn-primary">Nueva evaluación fotográfica</a>
+                                    </div>
                                 </div><!-- .nk-block-between -->
                             </div><!-- .nk-block-head -->
                             <div class="nk-block">
@@ -73,6 +76,49 @@ date_default_timezone_set('America/Mexico_City');
                                     </div>
                                 </div><!-- .card -->
                             </div><!-- .nk-block -->
+                            <div class="nk-block">
+                                <h4 class="nk-block-title">Evaluaciones fotográficas</h4>
+                                <div class="card card-full">
+                                    <div class="card-inner table-responsive">
+                                        <table class="table table-striped">
+                                            <thead>
+                                                <tr>
+                                                    <th>Título</th>
+                                                    <th>Fecha</th>
+                                                    <th>Acciones</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <?php
+                                                $dir = __DIR__ . '/uploads/evaluaciones';
+                                                $items = [];
+                                                if (is_dir($dir)) {
+                                                    foreach (scandir($dir) as $d) {
+                                                        if ($d === '.' || $d === '..') continue;
+                                                        $metaFile = $dir . '/' . $d . '/meta.json';
+                                                        if (is_file($metaFile)) {
+                                                            $meta = json_decode(file_get_contents($metaFile), true);
+                                                            $items[] = ['id' => $d, 'titulo' => $meta['titulo'] ?? $d, 'fecha' => $meta['fecha'] ?? ''];
+                                                        }
+                                                    }
+                                                }
+                                                foreach ($items as $it):
+                                                ?>
+                                                <tr>
+                                                    <td><?php echo htmlspecialchars($it['titulo']); ?></td>
+                                                    <td><?php echo htmlspecialchars($it['fecha']); ?></td>
+                                                    <td><a href="ver_evaluacion.php?id=<?php echo urlencode($it['id']); ?>" class="btn btn-sm btn-info">Ver</a></td>
+                                                </tr>
+                                                <?php endforeach; ?>
+                                                <?php if (empty($items)): ?>
+                                                <tr><td colspan="3">No hay evaluaciones fotográficas.</td></tr>
+                                                <?php endif; ?>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+
                         </div>
                     </div>
                 </div>

--- a/guardar_evaluacion.php
+++ b/guardar_evaluacion.php
@@ -1,0 +1,43 @@
+<?php
+// Procesa el formulario de subir evaluaciones fotográficas
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $titulo = trim($_POST['titulo'] ?? '');
+    if ($titulo === '') {
+        die('El título es obligatorio');
+    }
+
+    $baseDir = __DIR__ . '/uploads/evaluaciones';
+    if (!is_dir($baseDir)) {
+        mkdir($baseDir, 0777, true);
+    }
+
+    $folder = $baseDir . '/' . time();
+    if (!mkdir($folder, 0777, true)) {
+        die('No se pudo crear el directorio de la evaluación');
+    }
+
+    $imagenes = [];
+    if (!empty($_FILES['fotos']['name'][0])) {
+        foreach ($_FILES['fotos']['tmp_name'] as $i => $tmpName) {
+            if ($_FILES['fotos']['error'][$i] === UPLOAD_ERR_OK) {
+                $ext = strtolower(pathinfo($_FILES['fotos']['name'][$i], PATHINFO_EXTENSION));
+                $filename = 'img' . ($i + 1) . '.' . $ext;
+                move_uploaded_file($tmpName, $folder . '/' . $filename);
+                $imagenes[] = $filename;
+            }
+        }
+    }
+
+    $meta = [
+        'titulo' => $titulo,
+        'fecha' => date('Y-m-d H:i:s'),
+        'imagenes' => $imagenes
+    ];
+    file_put_contents($folder . '/meta.json', json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+
+    header('Location: evaluaciones.php');
+    exit;
+} else {
+    header('Location: subir_evaluacion.php');
+    exit;
+}

--- a/subir_evaluacion.php
+++ b/subir_evaluacion.php
@@ -1,0 +1,76 @@
+<?php
+include_once 'includes/head.php';
+?>
+            <!-- sidebar @e -->
+            <!-- wrap @s -->
+            <div class="nk-wrap ">
+                <!-- main header @s -->
+                <?php include_once 'includes/menu_superior.php'; ?>
+                <!-- main header @e -->
+                <!-- content @s -->
+                <div class="nk-content nk-content-fluid">
+                    <div class="container-xl wide-xl">
+                        <div class="nk-content-body">
+                            <div class="nk-block-head nk-block-head-sm">
+                                <div class="nk-block-between">
+                                    <div class="nk-block-head-content">
+                                        <h3 class="nk-block-title page-title">Subir evaluación fotográfica</h3>
+                                        <div class="nk-block-des text-soft">
+                                            <p>Capture una o varias fotos y asigne un título.</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="nk-block">
+                                <div class="card card-bordered">
+                                    <div class="card-inner">
+                                        <form action="guardar_evaluacion.php" method="POST" enctype="multipart/form-data">
+                                            <div class="row g-4">
+                                                <div class="col-12">
+                                                    <div class="form-group">
+                                                        <label class="form-label" for="titulo">Título</label>
+                                                        <div class="form-control-wrap">
+                                                            <input
+                                                                type="text"
+                                                                class="form-control"
+                                                                id="titulo"
+                                                                name="titulo"
+                                                                required
+                                                            >
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="col-12">
+                                                    <div class="form-group">
+                                                        <label class="form-label" for="fotos">Fotos</label>
+                                                        <div class="form-control-wrap">
+                                                            <input
+                                                                type="file"
+                                                                class="form-control"
+                                                                id="fotos"
+                                                                name="fotos[]"
+                                                                accept="image/*"
+                                                                capture="environment"
+                                                                multiple
+                                                                required
+                                                            >
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="col-12">
+                                                    <button type="submit" class="btn btn-primary">Guardar</button>
+                                                </div>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- content @e -->
+            </div>
+            <!-- wrap @e -->
+<?php
+include_once 'includes/footer.php';
+?>

--- a/ver_evaluacion.php
+++ b/ver_evaluacion.php
@@ -1,0 +1,57 @@
+<?php
+include_once 'includes/head.php';
+
+$id = basename($_GET['id'] ?? '');
+$baseDir = __DIR__ . '/uploads/evaluaciones/' . $id;
+$metaFile = $baseDir . '/meta.json';
+if (!is_file($metaFile)) {
+    die('Evaluación no encontrada');
+}
+$meta = json_decode(file_get_contents($metaFile), true);
+$imagenes = $meta['imagenes'] ?? [];
+?>
+            <!-- sidebar @e -->
+            <!-- wrap @s -->
+            <div class="nk-wrap ">
+                <!-- main header @s -->
+                <?php include_once 'includes/menu_superior.php'; ?>
+                <!-- main header @e -->
+                <!-- content @s -->
+                <div class="nk-content nk-content-fluid">
+                    <div class="container-xl wide-xl">
+                        <div class="nk-content-body">
+                            <div class="nk-block-head nk-block-head-sm">
+                                <div class="nk-block-between">
+                                    <div class="nk-block-head-content">
+                                        <h3 class="nk-block-title page-title"><?php echo htmlspecialchars($meta['titulo'] ?? ''); ?></h3>
+                                        <div class="nk-block-des text-soft">
+                                            <p><?php echo htmlspecialchars($meta['fecha'] ?? ''); ?></p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="nk-block">
+                                <div class="row g-gs">
+                                    <?php foreach ($imagenes as $img): ?>
+                                    <div class="col-sm-6 col-lg-4">
+                                        <div class="card card-bordered">
+                                            <img src="<?php echo '/uploads/evaluaciones/' . htmlspecialchars($id) . '/' . htmlspecialchars($img); ?>" class="card-img-top" alt="">
+                                        </div>
+                                    </div>
+                                    <?php endforeach; ?>
+                                    <?php if (empty($imagenes)): ?>
+                                    <div class="col-12">
+                                        <p>No hay imágenes para esta evaluación.</p>
+                                    </div>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- content @e -->
+            </div>
+            <!-- wrap @e -->
+<?php
+include_once 'includes/footer.php';
+?>


### PR DESCRIPTION
## Summary
- add form to upload photo-based evaluations with title
- store and display uploaded evaluation images

## Testing
- `php -l subir_evaluacion.php`
- `php -l guardar_evaluacion.php`
- `php -l ver_evaluacion.php`
- `php -l evaluaciones.php`


------
https://chatgpt.com/codex/tasks/task_e_689fddefa37083228eaab8fa97823fba