### PR TITLE
Add patient photo evaluation section with MySQL storage

### DIFF
--- a/database/queries.sql
+++ b/database/queries.sql
@@ -102,3 +102,19 @@ CREATE TABLE `exp_evaluacion_examen` (
     FOREIGN KEY (`id_nino`) REFERENCES `nino`(`Id`),
     FOREIGN KEY (`id_usuario`) REFERENCES `Usuarios`(`id`)
 );
+
+-- evaluaciones fotográficas de paciente
+CREATE TABLE `exp_evaluacion_fotos` (
+    `id_eval_foto` INT AUTO_INCREMENT PRIMARY KEY,
+    `id_nino` INT NOT NULL,
+    `titulo` VARCHAR(255) NOT NULL,
+    `fecha` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (`id_nino`) REFERENCES `nino`(`Id`)
+);
+
+CREATE TABLE `exp_evaluacion_fotos_imagenes` (
+    `id_imagen` INT AUTO_INCREMENT PRIMARY KEY,
+    `id_eval_foto` INT NOT NULL,
+    `ruta` VARCHAR(255) NOT NULL,
+    FOREIGN KEY (`id_eval_foto`) REFERENCES `exp_evaluacion_fotos`(`id_eval_foto`)
+);

--- a/pacientes/guardar_evaluacion_fotos.php
+++ b/pacientes/guardar_evaluacion_fotos.php
@@ -1,0 +1,46 @@
+<?php
+require_once '../database/conexion.php';
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$id_nino = intval($_POST['id_nino'] ?? 0);
+$titulo = trim($_POST['titulo'] ?? '');
+
+if ($id_nino <= 0 || $titulo === '') {
+    $db->closeConnection();
+    header('Location: paciente.php?id=' . $id_nino);
+    exit();
+}
+
+// Insertar evaluacion
+$stmt = $conn->prepare("INSERT INTO exp_evaluacion_fotos (id_nino, titulo) VALUES (?, ?)");
+$stmt->bind_param('is', $id_nino, $titulo);
+$stmt->execute();
+$id_eval = $stmt->insert_id;
+$stmt->close();
+
+$baseDir = __DIR__ . '/../uploads/pacientes/' . $id_nino . '/evaluaciones/' . $id_eval;
+if (!is_dir($baseDir)) {
+    mkdir($baseDir, 0777, true);
+}
+
+if (!empty($_FILES['fotos']['name'][0])) {
+    foreach ($_FILES['fotos']['tmp_name'] as $i => $tmpName) {
+        if ($_FILES['fotos']['error'][$i] === UPLOAD_ERR_OK) {
+            $ext = strtolower(pathinfo($_FILES['fotos']['name'][$i], PATHINFO_EXTENSION));
+            $filename = 'img' . ($i + 1) . '.' . $ext;
+            if (move_uploaded_file($tmpName, $baseDir . '/' . $filename)) {
+                $stmt = $conn->prepare("INSERT INTO exp_evaluacion_fotos_imagenes (id_eval_foto, ruta) VALUES (?, ?)");
+                $stmt->bind_param('is', $id_eval, $filename);
+                $stmt->execute();
+                $stmt->close();
+            }
+        }
+    }
+}
+
+$db->closeConnection();
+header('Location: paciente.php?id=' . $id_nino);
+exit();
+?>

--- a/pacientes/paciente.php
+++ b/pacientes/paciente.php
@@ -131,6 +131,16 @@ date_default_timezone_set('America/Mexico_City');
         $lista_examenes = $result->fetch_all(MYSQLI_ASSOC);
     }
 
+    $evaluaciones_fotos = [];
+    $stmt = $conn->prepare("SELECT ef.id_eval_foto, ef.titulo, ef.fecha, GROUP_CONCAT(ei.ruta) AS imagenes FROM exp_evaluacion_fotos ef LEFT JOIN exp_evaluacion_fotos_imagenes ei ON ef.id_eval_foto = ei.id_eval_foto WHERE ef.id_nino = ? GROUP BY ef.id_eval_foto ORDER BY ef.fecha DESC");
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result) {
+        $evaluaciones_fotos = $result->fetch_all(MYSQLI_ASSOC);
+    }
+    $stmt->close();
+
     $db->closeConnection();
     ?>
     <div class="nk-content nk-content-fluid">
@@ -346,6 +356,57 @@ date_default_timezone_set('America/Mexico_City');
                         <?php endif; ?>
                         </tbody>
                     </table>
+                </div>
+            </div>
+
+            <div class="card mt-4">
+                <div class="card-inner">
+                    <h5 class="title mb-3">Evaluaciones fotográficas</h5>
+                    <form action="guardar_evaluacion_fotos.php" method="POST" enctype="multipart/form-data" class="mb-4">
+                        <input type="hidden" name="id_nino" value="<?php echo $id; ?>">
+                        <div class="row g-4">
+                            <div class="col-12">
+                                <div class="form-group">
+                                    <label class="form-label" for="titulo_eval">Título</label>
+                                    <div class="form-control-wrap">
+                                        <input type="text" class="form-control" id="titulo_eval" name="titulo" required>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-12">
+                                <div class="form-group">
+                                    <label class="form-label" for="fotos_eval">Fotos</label>
+                                    <div class="form-control-wrap">
+                                        <input type="file" class="form-control" id="fotos_eval" name="fotos[]" accept="image/*" multiple required>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-12">
+                                <button type="submit" class="btn btn-primary">Guardar</button>
+                            </div>
+                        </div>
+                    </form>
+                    <div class="row g-gs">
+                        <?php foreach ($evaluaciones_fotos as $ev): ?>
+                        <div class="col-sm-6 col-lg-4">
+                            <div class="card card-bordered">
+                                <div class="card-inner">
+                                    <h6 class="title mb-2"><?php echo htmlspecialchars($ev['titulo']); ?></h6>
+                                    <div class="row g-2">
+                                        <?php foreach (array_filter(explode(',', $ev['imagenes'])) as $img): ?>
+                                        <div class="col-6">
+                                            <img src="../uploads/pacientes/<?php echo $id; ?>/evaluaciones/<?php echo $ev['id_eval_foto'] . '/' . htmlspecialchars($img); ?>" class="img-fluid" alt="">
+                                        </div>
+                                        <?php endforeach; ?>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <?php endforeach; ?>
+                        <?php if (empty($evaluaciones_fotos)): ?>
+                        <div class="col-12"><p>No hay evaluaciones fotográficas.</p></div>
+                        <?php endif; ?>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- create tables `exp_evaluacion_fotos` and `exp_evaluacion_fotos_imagenes` for storing patient photo evaluations
- add handler to store multiple uploaded images linked to a patient evaluation
- embed a new photo evaluation form and gallery within the patient detail page

## Testing
- `php -l pacientes/guardar_evaluacion_fotos.php`
- `php -l pacientes/paciente.php`


------
https://chatgpt.com/codex/tasks/task_e_68a12627ceb883228719c88aa96c1f66