### PR TITLE
Allow uploading any file type for evaluations

### DIFF
--- a/evaluaciones.php
+++ b/evaluaciones.php
@@ -36,7 +36,7 @@ date_default_timezone_set('America/Mexico_City');
                                         </div>
                                     </div><!-- .nk-block-head-content -->
                                     <div class="nk-block-head-content">
-                                        <a href="subir_evaluacion.php" class="btn btn-primary">Nueva evaluación fotográfica</a>
+                                        <a href="subir_evaluacion.php" class="btn btn-primary">Nuevo archivo de evaluación</a>
                                     </div>
                                 </div><!-- .nk-block-between -->
                             </div><!-- .nk-block-head -->
@@ -77,7 +77,7 @@ date_default_timezone_set('America/Mexico_City');
                                 </div><!-- .card -->
                             </div><!-- .nk-block -->
                             <div class="nk-block">
-                                <h4 class="nk-block-title">Evaluaciones fotográficas</h4>
+                                <h4 class="nk-block-title">Archivos de evaluaciones</h4>
                                 <div class="card card-full">
                                     <div class="card-inner table-responsive">
                                         <table class="table table-striped">
@@ -111,7 +111,7 @@ date_default_timezone_set('America/Mexico_City');
                                                 </tr>
                                                 <?php endforeach; ?>
                                                 <?php if (empty($items)): ?>
-                                                <tr><td colspan="3">No hay evaluaciones fotográficas.</td></tr>
+                                                <tr><td colspan="3">No hay archivos de evaluaciones.</td></tr>
                                                 <?php endif; ?>
                                             </tbody>
                                         </table>

--- a/guardar_evaluacion.php
+++ b/guardar_evaluacion.php
@@ -1,5 +1,5 @@
 <?php
-// Procesa el formulario de subir evaluaciones fotográficas
+// Procesa el formulario de subir archivos de evaluaciones
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $titulo = trim($_POST['titulo'] ?? '');
     if ($titulo === '') {
@@ -16,14 +16,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         die('No se pudo crear el directorio de la evaluación');
     }
 
-    $imagenes = [];
-    if (!empty($_FILES['fotos']['name'][0])) {
-        foreach ($_FILES['fotos']['tmp_name'] as $i => $tmpName) {
-            if ($_FILES['fotos']['error'][$i] === UPLOAD_ERR_OK) {
-                $ext = strtolower(pathinfo($_FILES['fotos']['name'][$i], PATHINFO_EXTENSION));
-                $filename = 'img' . ($i + 1) . '.' . $ext;
+    $archivos = [];
+    if (!empty($_FILES['archivos']['name'][0])) {
+        foreach ($_FILES['archivos']['tmp_name'] as $i => $tmpName) {
+            if ($_FILES['archivos']['error'][$i] === UPLOAD_ERR_OK) {
+                $info = pathinfo($_FILES['archivos']['name'][$i]);
+                $base = preg_replace('/[^A-Za-z0-9_-]/', '_', $info['filename']);
+                $ext = strtolower($info['extension'] ?? '');
+                $filename = $base . '_' . time() . '_' . $i . '.' . $ext;
                 move_uploaded_file($tmpName, $folder . '/' . $filename);
-                $imagenes[] = $filename;
+                $archivos[] = $filename;
             }
         }
     }
@@ -31,7 +33,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $meta = [
         'titulo' => $titulo,
         'fecha' => date('Y-m-d H:i:s'),
-        'imagenes' => $imagenes
+        'archivos' => $archivos
     ];
     file_put_contents($folder . '/meta.json', json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
 

--- a/subir_evaluacion.php
+++ b/subir_evaluacion.php
@@ -14,9 +14,9 @@ include_once 'includes/head.php';
                             <div class="nk-block-head nk-block-head-sm">
                                 <div class="nk-block-between">
                                     <div class="nk-block-head-content">
-                                        <h3 class="nk-block-title page-title">Subir evaluación fotográfica</h3>
+                                        <h3 class="nk-block-title page-title">Subir archivos de evaluación</h3>
                                         <div class="nk-block-des text-soft">
-                                            <p>Capture una o varias fotos y asigne un título.</p>
+                                            <p>Seleccione uno o varios archivos y asigne un título.</p>
                                         </div>
                                     </div>
                                 </div>
@@ -42,15 +42,13 @@ include_once 'includes/head.php';
                                                 </div>
                                                 <div class="col-12">
                                                     <div class="form-group">
-                                                        <label class="form-label" for="fotos">Fotos</label>
+                                                        <label class="form-label" for="archivos">Archivos</label>
                                                         <div class="form-control-wrap">
                                                             <input
                                                                 type="file"
                                                                 class="form-control"
-                                                                id="fotos"
-                                                                name="fotos[]"
-                                                                accept="image/*"
-                                                                capture="environment"
+                                                                id="archivos"
+                                                                name="archivos[]"
                                                                 multiple
                                                                 required
                                                             >

--- a/ver_evaluacion.php
+++ b/ver_evaluacion.php
@@ -8,7 +8,7 @@ if (!is_file($metaFile)) {
     die('Evaluación no encontrada');
 }
 $meta = json_decode(file_get_contents($metaFile), true);
-$imagenes = $meta['imagenes'] ?? [];
+$archivos = $meta['archivos'] ?? ($meta['imagenes'] ?? []);
 ?>
             <!-- sidebar @e -->
             <!-- wrap @s -->
@@ -31,20 +31,18 @@ $imagenes = $meta['imagenes'] ?? [];
                                 </div>
                             </div>
                             <div class="nk-block">
-                                <div class="row g-gs">
-                                    <?php foreach ($imagenes as $img): ?>
-                                    <div class="col-sm-6 col-lg-4">
-                                        <div class="card card-bordered">
-                                            <img src="<?php echo '/uploads/evaluaciones/' . htmlspecialchars($id) . '/' . htmlspecialchars($img); ?>" class="card-img-top" alt="">
-                                        </div>
-                                    </div>
+                                <ul class="list-group">
+                                    <?php foreach ($archivos as $file): ?>
+                                    <li class="list-group-item">
+                                        <a href="<?php echo '/uploads/evaluaciones/' . htmlspecialchars($id) . '/' . htmlspecialchars($file); ?>" target="_blank">
+                                            <?php echo htmlspecialchars($file); ?>
+                                        </a>
+                                    </li>
                                     <?php endforeach; ?>
-                                    <?php if (empty($imagenes)): ?>
-                                    <div class="col-12">
-                                        <p>No hay imágenes para esta evaluación.</p>
-                                    </div>
+                                    <?php if (empty($archivos)): ?>
+                                    <li class="list-group-item">No hay archivos para esta evaluación.</li>
                                     <?php endif; ?>
-                                </div>
+                                </ul>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Permit uploading evaluation files of any type and store them with sanitized names
- Update upload form and main listing to reflect generic evaluation files
- Display evaluation file lists as downloadable links

## Testing
- `php -l evaluaciones.php`
- `php -l subir_evaluacion.php`
- `php -l guardar_evaluacion.php`
- `php -l ver_evaluacion.php`


------
https://chatgpt.com/codex/tasks/task_e_68a38921895083228668ff52396819b5