### PR TITLE
Añadir opción para eliminar evaluaciones

### DIFF
--- a/eliminar_evaluacion.php
+++ b/eliminar_evaluacion.php
@@ -1,0 +1,37 @@
+<?php
+// Script para eliminar una evaluación cargada.
+// Recibe el identificador del directorio de la evaluación a través del parámetro GET "id".
+
+$id = isset($_GET['id']) ? basename($_GET['id']) : '';
+if ($id === '') {
+    header('Location: evaluaciones.php');
+    exit;
+}
+
+$dir = __DIR__ . '/uploads/evaluaciones/' . $id;
+
+// Función recursiva para eliminar un directorio completo
+function rrmdir(string $dirPath): void {
+    if (!is_dir($dirPath)) {
+        return;
+    }
+    foreach (scandir($dirPath) as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+        $fullPath = $dirPath . '/' . $item;
+        if (is_dir($fullPath)) {
+            rrmdir($fullPath);
+        } else {
+            @unlink($fullPath);
+        }
+    }
+    @rmdir($dirPath);
+}
+
+if (is_dir($dir)) {
+    rrmdir($dir);
+}
+
+header('Location: evaluaciones.php');
+exit;

--- a/evaluaciones.php
+++ b/evaluaciones.php
@@ -36,6 +36,7 @@ date_default_timezone_set('America/Mexico_City');
                                                     <th>Título</th>
                                                     <th>Fecha</th>
                                                     <th>Archivos</th>
+                                                    <th>Eliminar</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
@@ -67,10 +68,13 @@ date_default_timezone_set('America/Mexico_City');
                                                             <a href="<?php echo '/uploads/evaluaciones/' . rawurlencode($it['id']) . '/' . rawurlencode($file); ?>" target="_blank"><?php echo htmlspecialchars($file); ?></a><br>
                                                         <?php endforeach; ?>
                                                     </td>
+                                                    <td>
+                                                        <a href="eliminar_evaluacion.php?id=<?php echo rawurlencode($it['id']); ?>" class="btn btn-danger btn-sm" onclick="return confirm('¿Eliminar esta evaluación?');">Eliminar</a>
+                                                    </td>
                                                 </tr>
                                                 <?php endforeach; ?>
                                                 <?php if (empty($items)): ?>
-                                                <tr><td colspan="3">No hay archivos.</td></tr>
+                                                <tr><td colspan="4">No hay archivos.</td></tr>
                                                 <?php endif; ?>
                                             </tbody>
                                         </table>


### PR DESCRIPTION
## Summary
- Mostrar botón para eliminar cada evaluación en el listado
- Implementar script `eliminar_evaluacion.php` para borrar directorios de evaluaciones

## Testing
- `php -l evaluaciones.php`
- `php -l eliminar_evaluacion.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9e0c6a8d08322ab445dc64f194de9