### PR TITLE
Limit delete actions for role 2

### DIFF
--- a/areas/delete.php
+++ b/areas/delete.php
@@ -1,4 +1,9 @@
 <?php
+session_start();
+if (!isset($_SESSION['rol']) || $_SESSION['rol'] == 2) {
+    header('Location: index.php');
+    exit;
+}
 require_once '../database/conexion.php';
 
 $id = $_GET['id'] ?? null;

--- a/areas/index.php
+++ b/areas/index.php
@@ -79,7 +79,9 @@ date_default_timezone_set('America/Mexico_City');
                                                                 <div class="dropdown-menu dropdown-menu-end">
                                                                     <ul class="link-list-plain no-bdr">
                                                                         <li><a href="/areas/form.php?id=<?php echo urlencode($a['id_area']); ?>"><em class="icon ni ni-edit"></em><span>Editar</span></a></li>
+                                                                        <?php if ($_SESSION['rol'] != 2): ?>
                                                                         <li><a href="/areas/delete.php?id=<?php echo urlencode($a['id_area']); ?>" onclick="return confirm('¿Eliminar área?');"><em class="icon ni ni-trash"></em><span>Eliminar</span></a></li>
+                                                                        <?php endif; ?>
                                                                     </ul>
                                                                 </div>
                                                             </div>

--- a/eliminar_evaluacion.php
+++ b/eliminar_evaluacion.php
@@ -2,6 +2,12 @@
 // Script para eliminar una evaluación cargada.
 // Recibe el identificador del directorio de la evaluación a través del parámetro GET "id".
 
+session_start();
+if (!isset($_SESSION['rol']) || $_SESSION['rol'] == 2) {
+    header('Location: evaluaciones.php');
+    exit;
+}
+
 $id = isset($_GET['id']) ? basename($_GET['id']) : '';
 if ($id === '') {
     header('Location: evaluaciones.php');

--- a/evaluaciones.php
+++ b/evaluaciones.php
@@ -36,7 +36,9 @@ date_default_timezone_set('America/Mexico_City');
                                                     <th>Título</th>
                                                     <th>Fecha</th>
                                                     <th>Archivos</th>
+                                                    <?php if ($_SESSION['rol'] != 2): ?>
                                                     <th>Eliminar</th>
+                                                    <?php endif; ?>
                                                 </tr>
                                             </thead>
                                             <tbody>
@@ -68,13 +70,15 @@ date_default_timezone_set('America/Mexico_City');
                                                             <a href="<?php echo '/uploads/evaluaciones/' . rawurlencode($it['id']) . '/' . rawurlencode($file); ?>" target="_blank"><?php echo htmlspecialchars($file); ?></a><br>
                                                         <?php endforeach; ?>
                                                     </td>
+                                                    <?php if ($_SESSION['rol'] != 2): ?>
                                                     <td>
                                                         <a href="eliminar_evaluacion.php?id=<?php echo rawurlencode($it['id']); ?>" class="btn btn-danger btn-sm" onclick="return confirm('¿Eliminar esta evaluación?');">Eliminar</a>
                                                     </td>
+                                                    <?php endif; ?>
                                                 </tr>
                                                 <?php endforeach; ?>
                                                 <?php if (empty($items)): ?>
-                                                <tr><td colspan="4">No hay archivos.</td></tr>
+                                                <tr><td colspan="<?php echo ($_SESSION['rol'] != 2) ? 4 : 3; ?>">No hay archivos.</td></tr>
                                                 <?php endif; ?>
                                             </tbody>
                                         </table>

--- a/examenes/index.php
+++ b/examenes/index.php
@@ -39,12 +39,14 @@ date_default_timezone_set('America/Mexico_City');
                 }
                 break;
             case 'delete_section':
-                $section_id = (int)($_POST['section_id'] ?? 0);
-                if ($section_id > 0) {
-                    $stmt = $conn->prepare("DELETE FROM exp_secciones_examen WHERE id_seccion = ?");
-                    $stmt->bind_param('i', $section_id);
-                    $stmt->execute();
-                    $stmt->close();
+                if ($_SESSION['rol'] != 2) {
+                    $section_id = (int)($_POST['section_id'] ?? 0);
+                    if ($section_id > 0) {
+                        $stmt = $conn->prepare("DELETE FROM exp_secciones_examen WHERE id_seccion = ?");
+                        $stmt->bind_param('i', $section_id);
+                        $stmt->execute();
+                        $stmt->close();
+                    }
                 }
                 break;
             case 'add_question':
@@ -68,12 +70,14 @@ date_default_timezone_set('America/Mexico_City');
                 }
                 break;
             case 'delete_question':
-                $question_id = (int)($_POST['question_id'] ?? 0);
-                if ($question_id > 0) {
-                    $stmt = $conn->prepare("DELETE FROM exp_preguntas_evaluacion WHERE id_pregunta = ?");
-                    $stmt->bind_param('i', $question_id);
-                    $stmt->execute();
-                    $stmt->close();
+                if ($_SESSION['rol'] != 2) {
+                    $question_id = (int)($_POST['question_id'] ?? 0);
+                    if ($question_id > 0) {
+                        $stmt = $conn->prepare("DELETE FROM exp_preguntas_evaluacion WHERE id_pregunta = ?");
+                        $stmt->bind_param('i', $question_id);
+                        $stmt->execute();
+                        $stmt->close();
+                    }
                 }
                 break;
         }
@@ -148,11 +152,13 @@ date_default_timezone_set('America/Mexico_City');
                                                 <input type="text" name="section_name" value="<?php echo htmlspecialchars($s['nombre_seccion']); ?>" class="form-control form-control-sm">
                                                 <button type="submit" class="btn btn-success btn-sm ms-2">Guardar</button>
                                             </form>
+                                            <?php if ($_SESSION['rol'] != 2): ?>
                                             <form method="post" class="ms-2" onsubmit="return confirm('¿Eliminar sección?');">
                                                 <input type="hidden" name="action" value="delete_section">
                                                 <input type="hidden" name="section_id" value="<?php echo $s['id_seccion']; ?>">
                                                 <button type="submit" class="btn btn-danger btn-sm">Eliminar</button>
                                             </form>
+                                            <?php endif; ?>
                                         </div>
                                         <?php if (!empty($s['preguntas'])): ?>
                                             <table class="table table-striped">
@@ -186,12 +192,14 @@ date_default_timezone_set('America/Mexico_City');
                                                                                         </button>
                                                                                     </form>
                                                                                 </li>
+                                                                                <?php if ($_SESSION['rol'] != 2): ?>
                                                                                 <li class="divider"></li>
                                                                                 <li>                                                                <form method="post" class="d-inline ms-2" onsubmit="return confirm('¿Eliminar pregunta?');">
                                                                     <input type="hidden" name="action" value="delete_question">
                                                                     <input type="hidden" name="question_id" value="<?php echo $p['id_pregunta']; ?>">
                                                                     <button type="submit" class="btn btn-danger btn-sm"> <em class="icon ni ni-download"></em> Eliminar</button>
                                                                 </form></li>
+                                                                                <?php endif; ?>
                                                                               
                                                                             </ul>
                                                                         </div>

--- a/examenes/pregunta_opciones.php
+++ b/examenes/pregunta_opciones.php
@@ -72,12 +72,14 @@ date_default_timezone_set('America/Mexico_City');
                             break;
 
                         case 'delete_option':
-                            $option_id = (int)($_POST['option_id'] ?? 0);
-                            if ($question_id > 0 && $option_id > 0) {
-                                $stmt = $conn->prepare("DELETE FROM exp_pregunta_opcion WHERE id_pregunta = ? AND id_opcion = ?");
-                                $stmt->bind_param('ii', $question_id, $option_id);
-                                $stmt->execute();
-                                $stmt->close();
+                            if ($_SESSION['rol'] != 2) {
+                                $option_id = (int)($_POST['option_id'] ?? 0);
+                                if ($question_id > 0 && $option_id > 0) {
+                                    $stmt = $conn->prepare("DELETE FROM exp_pregunta_opcion WHERE id_pregunta = ? AND id_opcion = ?");
+                                    $stmt->bind_param('ii', $question_id, $option_id);
+                                    $stmt->execute();
+                                    $stmt->close();
+                                }
                             }
                             break;
                     }
@@ -138,11 +140,13 @@ date_default_timezone_set('America/Mexico_City');
                                             <tr>
                                                 <td><?php echo htmlspecialchars($o['texto']); ?></td>
                                                 <td>
+                                                    <?php if ($_SESSION['rol'] != 2): ?>
                                                     <form method="post" class="d-inline" onsubmit="return confirm('¿Eliminar opción?');">
                                                         <input type="hidden" name="action" value="delete_option">
                                                         <input type="hidden" name="option_id" value="<?php echo $o['id_opcion']; ?>">
                                                         <button type="submit" class="btn btn-danger btn-sm">Eliminar</button>
                                                     </form>
+                                                    <?php endif; ?>
                                                 </td>
                                             </tr>
                                         <?php endforeach; ?>

--- a/pacientes/delete_exam.php
+++ b/pacientes/delete_exam.php
@@ -1,5 +1,11 @@
 <?php
 header('Content-Type: application/json');
+session_start();
+if (!isset($_SESSION['rol']) || $_SESSION['rol'] == 2) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'No autorizado']);
+    exit;
+}
 
 $id = isset($_POST['id']) ? intval($_POST['id']) : 0;
 $file = $_POST['file'] ?? '';

--- a/pacientes/eliminar_examen_evaluacion.php
+++ b/pacientes/eliminar_examen_evaluacion.php
@@ -1,5 +1,11 @@
 <?php
 header('Content-Type: application/json');
+session_start();
+if (!isset($_SESSION['rol']) || $_SESSION['rol'] == 2) {
+    http_response_code(403);
+    echo json_encode(['success' => false]);
+    exit;
+}
 require_once '../database/conexion.php';
 
 $id_eval = intval($_POST['id_eval'] ?? 0);

--- a/pacientes/evaluacion_examen.php
+++ b/pacientes/evaluacion_examen.php
@@ -74,7 +74,9 @@ if ($id_examen === 0) {
                         echo '<div class="d-flex gap-1">';
                         if ($status_eval !== 1) {
                             echo '<a class="btn btn-warning btn-sm" href="evaluacion_examen.php?id=' . $id_nino . '&examen=' . $ex['id_examen'] . '&eval=' . $id_eval . '">Editar</a>';
-                            echo '<button type="button" class="btn btn-danger btn-sm delete-eval" data-id="' . $id_eval . '">Eliminar</button>';
+                            if ($_SESSION['rol'] != 2) {
+                                echo '<button type="button" class="btn btn-danger btn-sm delete-eval" data-id="' . $id_eval . '">Eliminar</button>';
+                            }
                         }
                         echo '<a class="btn btn-success btn-sm" target="_blank" href="pdf_evaluacion_examen.php?id=' . $id_eval . '">Ver</a>';
                         echo '</div>';
@@ -197,7 +199,7 @@ if ($id_examen === 0) {
             echo '<button type="button" class="btn btn-primary" onclick="nextSec(' . $secIndex . ')">Siguiente</button>';
         } else {
             echo '<button type="submit" class="btn btn-success me-2">Guardar</button>';
-            if ($id_eval > 0) {
+            if ($id_eval > 0 && $_SESSION['rol'] != 2) {
                 echo '<button type="button" class="btn btn-outline-danger me-2" onclick="deleteEval(' . $id_eval . ')">Eliminar</button>';
             }
             echo '<button type="button" class="btn btn-danger" onclick="finalizeExam()">Finalizar</button>';
@@ -225,6 +227,8 @@ function prevSec(n){saveProgress(()=>{document.getElementById('sec'+n).style.dis
 function finalizeExam(){document.getElementById('status').value=1;const data=collectData();document.getElementById('respuestas').value=JSON.stringify(data);form.submit();}
 if(form){form.addEventListener('submit',function(){const data=collectData();document.getElementById('respuestas').value=JSON.stringify(data);});}
 function deleteEval(id){if(!confirm('¿Eliminar evaluación?'))return;const params=new URLSearchParams();params.append('id_eval',id);params.append('id_nino','<?php echo $id_nino; ?>');fetch('eliminar_examen_evaluacion.php',{method:'POST',body:params}).then(r=>r.json()).then(res=>{if(res.success){window.location.href='evaluacion_examen.php?id=<?php echo $id_nino; ?>';}else{alert('No se pudo eliminar');}});}
+<?php if ($_SESSION['rol'] != 2): ?>
 document.querySelectorAll('.delete-eval').forEach(btn=>{btn.addEventListener('click',()=>deleteEval(btn.getAttribute('data-id')));});
+<?php endif; ?>
 </script>
 <?php include_once '../includes/footer.php'; ?>

--- a/pacientes/paciente.php
+++ b/pacientes/paciente.php
@@ -366,7 +366,7 @@ date_default_timezone_set('America/Mexico_City');
                 <ul class="link-list-plain no-bdr">
                     <li><a href="' . $url . '" target="_blank"><em class="icon ni ni-eye"></em><span>Ver</span></a></li>
                     <li><a href="' . $url . '" download><em class="icon ni ni-download"></em><span>Descargar</span></a></li>
-                    <li><a href="#" class="delete-exam" data-file="' . htmlspecialchars($f) . '"><em class="icon ni ni-trash"></em><span>Eliminar</span></a></li>
+                    ' . (($_SESSION['rol'] != 2) ? '<li><a href="#" class="delete-exam" data-file="' . htmlspecialchars($f) . '"><em class="icon ni ni-trash"></em><span>Eliminar</span></a></li>' : '') . '
                 </ul>
             </div>
         </div>
@@ -693,6 +693,7 @@ date_default_timezone_set('America/Mexico_City');
         });
     }
 
+    <?php if ($_SESSION['rol'] != 2): ?>
     document.querySelectorAll('.delete-exam').forEach(btn => {
         btn.addEventListener('click', function(e) {
             e.preventDefault();
@@ -724,6 +725,7 @@ date_default_timezone_set('America/Mexico_City');
             });
         });
     });
+    <?php endif; ?>
 </script>
 <?php include_once '../includes/modalEvaluacion.php'; ?>
 <?php include_once '../includes/modalProgreso.php'; ?>


### PR DESCRIPTION
## Summary
- Hide evaluation deletion column for users with role 2 and block direct access to deletion script.
- Remove delete controls for role 2 in patient files, exam evaluations, exam builder, and area management.
- Add server-side checks preventing role 2 from invoking delete endpoints.

## Testing
- `php -l evaluaciones.php eliminar_evaluacion.php pacientes/paciente.php pacientes/delete_exam.php pacientes/evaluacion_examen.php pacientes/eliminar_examen_evaluacion.php examenes/index.php examenes/pregunta_opciones.php areas/index.php areas/delete.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa01421b408322bcac40db3b1692e4