### PR TITLE
Enable admin exam deletion

### DIFF
--- a/areas/delete_examen.php
+++ b/areas/delete_examen.php
@@ -1,0 +1,24 @@
+<?php
+session_start();
+if (!isset($_SESSION['rol']) || $_SESSION['rol'] == 2) {
+    header('Location: examenes.php');
+    exit;
+}
+require_once '../database/conexion.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$area_id = isset($_GET['area_id']) ? (int)$_GET['area_id'] : 0;
+if ($id > 0) {
+    $db = new Database();
+    $conn = $db->getConnection();
+    $stmt = $conn->prepare('DELETE FROM exp_examenes WHERE id_examen = ?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $stmt->close();
+    $db->closeConnection();
+}
+
+$redirect = $area_id > 0 ? 'examenes.php?id=' . urlencode($area_id) : 'index.php';
+header('Location: ' . $redirect);
+exit;
+?>

--- a/areas/examenes.php
+++ b/areas/examenes.php
@@ -52,6 +52,9 @@ date_default_timezone_set('America/Mexico_City');
                                             <p>Exámenes del área: <?php echo htmlspecialchars($area_nombre); ?></p>
                                         </div>
                                     </div><!-- .nk-block-head-content -->
+                                    <div class="nk-block-head-content">
+                                        <a href="javascript:history.back()" class="btn btn-secondary"><em class="icon ni ni-arrow-left"></em><span>Atrás</span></a>
+                                    </div>
                                 </div><!-- .nk-block-between -->
                             </div><!-- .nk-block-head -->
                             <div class="nk-block">
@@ -82,6 +85,20 @@ date_default_timezone_set('America/Mexico_City');
                                                                 <li class="date">ID: <?php echo htmlspecialchars($e['id_examen']); ?></li>
                                                             </ul>
                                                         </div>
+                                                        <?php if ($_SESSION['rol'] != 2): ?>
+                                                        <div class="nk-file-actions">
+                                                            <div class="dropdown">
+                                                                <a href="#" class="dropdown-toggle btn btn-sm btn-icon btn-trigger" data-bs-toggle="dropdown">
+                                                                    <em class="icon ni ni-more-h"></em>
+                                                                </a>
+                                                                <div class="dropdown-menu dropdown-menu-end">
+                                                                    <ul class="link-list-plain no-bdr">
+                                                                        <li><a href="/areas/delete_examen.php?id=<?php echo urlencode($e['id_examen']); ?>&area_id=<?php echo urlencode($area_id); ?>" onclick="return confirm('¿Eliminar examen?');"><em class="icon ni ni-trash"></em><span>Eliminar</span></a></li>
+                                                                    </ul>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                        <?php endif; ?>
                                                     </div>
                                                 <?php endforeach; ?>
                                                 <?php if (empty($examenes)): ?>

--- a/evaluaciones.php
+++ b/evaluaciones.php
@@ -22,7 +22,8 @@ date_default_timezone_set('America/Mexico_City');
                                             <p>Listado de archivos disponibles.</p>
                                         </div>
                                     </div><!-- .nk-block-head-content -->
-                                    <div class="nk-block-head-content">
+                                    <div class="nk-block-head-content d-flex align-items-center">
+                                        <a href="javascript:history.back()" class="btn btn-secondary me-2"><em class="icon ni ni-arrow-left"></em><span>Atrás</span></a>
                                         <a href="subir_evaluacion.php" class="btn btn-primary">Subir archivo</a>
                                     </div>
                                 </div><!-- .nk-block-between -->

--- a/examenes/index.php
+++ b/examenes/index.php
@@ -161,6 +161,9 @@ date_default_timezone_set('America/Mexico_City');
                                 </div>
                             </form>
                         </div><!-- .nk-block-head-content -->
+                        <div class="nk-block-head-content">
+                            <a href="/areas/examenes.php?id=<?php echo urlencode($exam_area); ?>" class="btn btn-secondary"><em class="icon ni ni-arrow-left"></em><span>Atrás</span></a>
+                        </div>
                     </div><!-- .nk-block-between -->
                 </div><!-- .nk-block-head -->
                 <div class="nk-block">


### PR DESCRIPTION
## Summary
- Allow admins to delete exams from area listings
- Add back buttons to evaluation and exam pages to keep navigation context

## Testing
- `php -l evaluaciones.php`
- `php -l areas/examenes.php`
- `php -l examenes/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab9e82d8e08322a523a5de29ffbb6b