### PR TITLE
Enable admin deletion of photo evaluation records

### DIFF
--- a/pacientes/eliminar_evaluacion_fotos.php
+++ b/pacientes/eliminar_evaluacion_fotos.php
@@ -1,0 +1,65 @@
+<?php
+header('Content-Type: application/json');
+session_start();
+if (!isset($_SESSION['rol']) || $_SESSION['rol'] == 2) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'No autorizado']);
+    exit;
+}
+require_once '../database/conexion.php';
+
+$id_eval = intval($_POST['id_eval'] ?? 0);
+if ($id_eval <= 0) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Datos invalidos']);
+    exit;
+}
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$stmt = $conn->prepare("SELECT id_nino, seccion FROM exp_evaluacion_fotos WHERE id_eval_foto=?");
+$stmt->bind_param('i', $id_eval);
+$stmt->execute();
+$result = $stmt->get_result();
+$info = $result->fetch_assoc();
+$stmt->close();
+if (!$info) {
+    $db->closeConnection();
+    http_response_code(404);
+    echo json_encode(['success' => false, 'message' => 'Evaluación no encontrada']);
+    exit;
+}
+$id_nino = $info['id_nino'];
+$seccion_dir = preg_replace('/[^a-zA-Z0-9_-]/', '_', strtolower($info['seccion']));
+$baseDir = __DIR__ . '/../uploads/pacientes/' . $id_nino . '/evaluaciones/' . $seccion_dir . '/' . $id_eval;
+
+function rrmdir($dir) {
+    if (!is_dir($dir)) return;
+    foreach (scandir($dir) as $item) {
+        if ($item === '.' || $item === '..') continue;
+        $path = $dir . '/' . $item;
+        if (is_dir($path)) {
+            rrmdir($path);
+        } else {
+            @unlink($path);
+        }
+    }
+    @rmdir($dir);
+}
+rrmdir($baseDir);
+
+$stmt = $conn->prepare("DELETE FROM exp_evaluacion_fotos_imagenes WHERE id_eval_foto=?");
+$stmt->bind_param('i', $id_eval);
+$stmt->execute();
+$stmt->close();
+
+$stmt = $conn->prepare("DELETE FROM exp_evaluacion_fotos WHERE id_eval_foto=?");
+$stmt->bind_param('i', $id_eval);
+$stmt->execute();
+$success = $stmt->affected_rows > 0;
+$stmt->close();
+
+$db->closeConnection();
+
+echo json_encode(['success' => $success]);

--- a/pacientes/paciente.php
+++ b/pacientes/paciente.php
@@ -309,6 +309,11 @@ date_default_timezone_set('America/Mexico_City');
                                         <a href="detalleEvaluacion.php?id=<?php echo $ev['id_eval_foto']; ?>" class="btn btn-sm btn-outline-secondary">
                                             <em class="icon ni ni-eye"></em> Ver
                                         </a>
+                                        <?php if ($_SESSION['rol'] != 2): ?>
+                                        <a href="#" class="btn btn-sm btn-outline-danger delete-eval-foto" data-id="<?php echo $ev['id_eval_foto']; ?>">
+                                            <em class="icon ni ni-trash"></em> Eliminar
+                                        </a>
+                                        <?php endif; ?>
                                         <!--
                                         <div class="row g-2">
                                             <?php //foreach (array_filter(explode(',', $ev['imagenes'])) as $img): ?>
@@ -719,6 +724,37 @@ date_default_timezone_set('America/Mexico_City');
     }
 
     <?php if ($_SESSION['rol'] != 2): ?>
+    document.querySelectorAll('.delete-eval-foto').forEach(btn => {
+        btn.addEventListener('click', function(e){
+            e.preventDefault();
+            const idEval = this.getAttribute('data-id');
+            Swal.fire({
+                title: '¿Eliminar evaluación?',
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonText: 'Sí, eliminar'
+            }).then(res => {
+                if (res.isConfirmed) {
+                    const fd = new FormData();
+                    fd.append('id_eval', idEval);
+                    fetch('eliminar_evaluacion_fotos.php', {
+                        method: 'POST',
+                        body: fd
+                    })
+                    .then(r => r.json())
+                    .then(resp => {
+                        if (resp.success) {
+                            Swal.fire('Eliminado', '', 'success').then(() => location.reload());
+                        } else {
+                            Swal.fire('Error', resp.message || 'Ocurrió un error', 'error');
+                        }
+                    })
+                    .catch(() => Swal.fire('Error', 'Ocurrió un error', 'error'));
+                }
+            });
+        });
+    });
+
     document.querySelectorAll('.delete-exam').forEach(btn => {
         btn.addEventListener('click', function(e) {
             e.preventDefault();


### PR DESCRIPTION
## Summary
- Show evaluation photos grouped by section in patient page with admin-only delete buttons
- Add endpoint to remove photo evaluations and associated images from database and filesystem

## Testing
- `php -l pacientes/eliminar_evaluacion_fotos.php`
- `php -l pacientes/paciente.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae2b24911c83229fde40b58ac6fd3e