### PR TITLE
Handle page overflow in evaluation PDF generation

### DIFF
--- a/pacientes/pdf_evaluacion_examen.php
+++ b/pacientes/pdf_evaluacion_examen.php
@@ -28,23 +28,40 @@ $resp = json_decode($eval['respuestas'], true) ?: [];
 $pdf = new SimplePDF();
 $pdf->addPage();
 
+
 $pdf->text(40,40,'Evaluación: '.$eval['nombre_examen']);
 $pdf->text(40,60,'Paciente: '.$eval['paciente']);
 $pdf->text(40,80,'Fecha: '.$eval['fecha']);
 $pdf->text(40,100,'Aplicó: '.$eval['usuario']);
 $y = 130;
+$pageLimit = 800; // Approximate bottom margin of the page
 
 $i=1;
 foreach($resp as $r){
-    $pdf->text(40,$y,$i.'. '.$r['pregunta']);
-    $y+=20;
-    $pdf->text(60,$y,'Respuesta: '.$r['respuesta']);
-    $y+=20;
-    if(!empty($r['comentario'])){
-        $pdf->text(60,$y,'Comentario: '.$r['comentario']);
-        $y+=20;
+    if($y > $pageLimit){
+        $pdf->addPage();
+        $y = 40;
     }
-    $y+=10;
+    $pdf->text(40,$y,$i.'. '.$r['pregunta']);
+    $y += 20;
+
+    if($y > $pageLimit){
+        $pdf->addPage();
+        $y = 40;
+    }
+    $pdf->text(60,$y,'Respuesta: '.$r['respuesta']);
+    $y += 20;
+
+    if(!empty($r['comentario'])){
+        if($y > $pageLimit){
+            $pdf->addPage();
+            $y = 40;
+        }
+        $pdf->text(60,$y,'Comentario: '.$r['comentario']);
+        $y += 20;
+    }
+
+    $y += 10;
     $i++;
 }
 header('Content-Type: application/pdf');


### PR DESCRIPTION
## Summary
- Add page overflow handling in `pdf_evaluacion_examen.php` to avoid truncated output by adding a new page when content exceeds page limit

## Testing
- `php -l pacientes/pdf_evaluacion_examen.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae5d8781cc83228a9e9d0dc66d2ce4