### PR TITLE
Mostrar secciones y quitar numeración en PDF de evaluación

### DIFF
--- a/pacientes/pdf_evaluacion_examen.php
+++ b/pacientes/pdf_evaluacion_examen.php
@@ -11,13 +11,28 @@ $db = new Database();
 $conn = $db->getConnection();
 
 
-$stmt = $conn->prepare("SELECT ee.respuestas, ee.fecha, n.name AS paciente, u.name AS usuario, ex.nombre_examen FROM exp_evaluacion_examen ee JOIN nino n ON ee.id_nino=n.Id JOIN Usuarios u ON ee.id_usuario=u.id JOIN exp_examenes ex ON ee.id_examen = ex.id_examen WHERE ee.id_eval=? LIMIT 1");
+$stmt = $conn->prepare("SELECT ee.respuestas, ee.fecha, ee.id_examen, n.name AS paciente, u.name AS usuario, ex.nombre_examen FROM exp_evaluacion_examen ee JOIN nino n ON ee.id_nino=n.Id JOIN Usuarios u ON ee.id_usuario=u.id JOIN exp_examenes ex ON ee.id_examen = ex.id_examen WHERE ee.id_eval=? LIMIT 1");
 
 $stmt->bind_param('i',$id);
 $stmt->execute();
 $res = $stmt->get_result();
 $eval = $res ? $res->fetch_assoc() : null;
 $stmt->close();
+
+// Map question ids to their section names
+$sectionMap = [];
+if($eval){
+    $stmt = $conn->prepare("SELECT pe.id_pregunta, se.nombre_seccion FROM exp_preguntas_evaluacion pe JOIN exp_secciones_examen se ON pe.id_seccion = se.id_seccion WHERE se.id_examen=? ORDER BY se.id_seccion, pe.id_pregunta");
+    $stmt->bind_param('i',$eval['id_examen']);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if($res){
+        while($row = $res->fetch_assoc()){
+            $sectionMap[$row['id_pregunta']] = $row['nombre_seccion'];
+        }
+    }
+    $stmt->close();
+}
 $db->closeConnection();
 
 if(!$eval){
@@ -36,13 +51,25 @@ $pdf->text(40,100,'Aplicó: '.$eval['usuario']);
 $y = 130;
 $pageLimit = 800; // Approximate bottom margin of the page
 
-$i=1;
+$currentSection = '';
 foreach($resp as $r){
+    $qid = isset($r['id']) ? intval(preg_replace('/\D/','', $r['id'])) : 0;
+    $secName = $sectionMap[$qid] ?? '';
+    if($secName !== $currentSection){
+        if($y > $pageLimit){
+            $pdf->addPage();
+            $y = 40;
+        }
+        $pdf->text(40,$y,'Sección: '.$secName);
+        $y += 20;
+        $currentSection = $secName;
+    }
+
     if($y > $pageLimit){
         $pdf->addPage();
         $y = 40;
     }
-    $pdf->text(40,$y,$i.'. '.$r['pregunta']);
+    $pdf->text(40,$y,$r['pregunta']);
     $y += 20;
 
     if($y > $pageLimit){
@@ -62,7 +89,6 @@ foreach($resp as $r){
     }
 
     $y += 10;
-    $i++;
 }
 header('Content-Type: application/pdf');
 echo $pdf->output();


### PR DESCRIPTION
## Summary
- Mapear preguntas a sus secciones para cada evaluación y obtener el id del examen
- Mostrar encabezados de sección en el PDF de evaluación y eliminar numeración de preguntas

## Testing
- `php -l pacientes/pdf_evaluacion_examen.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae5f9d67a08322ae282f398422e386