### PR TITLE
Ensure edit form redirects before output and clean navigation whitespace

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -1,5 +1,4 @@
-           
-           <?php
+<?php
 function isActive($page) {
     return (basename($_SERVER['PHP_SELF']) == $page) ? ' active' : '';
 }

--- a/pacientes/editar_nombre.php
+++ b/pacientes/editar_nombre.php
@@ -1,43 +1,43 @@
 <?php
-include_once '../includes/head.php';
+require_once '../database/conexion.php';
 date_default_timezone_set('America/Mexico_City');
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $nuevo_nombre = trim($_POST['name'] ?? '');
+    if ($id > 0 && $nuevo_nombre !== '') {
+        $stmt = $conn->prepare("UPDATE nino SET name = ? WHERE Id = ?");
+        $stmt->bind_param('si', $nuevo_nombre, $id);
+        $stmt->execute();
+        $stmt->close();
+        $db->closeConnection();
+        header("Location: paciente.php?id=$id");
+        exit;
+    }
+}
+
+$nombre = '';
+if ($id > 0) {
+    $stmt = $conn->prepare("SELECT name FROM nino WHERE Id = ? LIMIT 1");
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($result) {
+        $row = $result->fetch_assoc();
+        $nombre = $row['name'] ?? '';
+    }
+    $stmt->close();
+}
+$db->closeConnection();
+
+include_once '../includes/head.php';
 ?>
 <div class="nk-wrap ">
-    <?php
-    include_once '../includes/menu_superior.php';
-    require_once '../database/conexion.php';
-    $db = new Database();
-    $conn = $db->getConnection();
-
-    $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-
-    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-        $nuevo_nombre = trim($_POST['name'] ?? '');
-        if ($id > 0 && $nuevo_nombre !== '') {
-            $stmt = $conn->prepare("UPDATE nino SET name = ? WHERE Id = ?");
-            $stmt->bind_param('si', $nuevo_nombre, $id);
-            $stmt->execute();
-            $stmt->close();
-            $db->closeConnection();
-            header("Location: paciente.php?id=$id");
-            exit;
-        }
-    }
-
-    $nombre = '';
-    if ($id > 0) {
-        $stmt = $conn->prepare("SELECT name FROM nino WHERE Id = ? LIMIT 1");
-        $stmt->bind_param('i', $id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        if ($result) {
-            $row = $result->fetch_assoc();
-            $nombre = $row['name'] ?? '';
-        }
-        $stmt->close();
-    }
-    $db->closeConnection();
-    ?>
+    <?php include_once '../includes/menu_superior.php'; ?>
     <div class="nk-content nk-content-fluid">
         <div class="container-xl wide-xl">
             <div class="nk-content-body">


### PR DESCRIPTION
## Summary
- Move database init and POST-handling to top of edit name script with early redirect to avoid headers already sent
- Include page header only after redirect logic completes
- Remove stray whitespace from navigation include to prevent unintended output

## Testing
- `php -l pacientes/editar_nombre.php`
- `php -l includes/navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_68af97855824832283b517ae443dec54