### PR TITLE
Add image management to evaluation detail

### DIFF
--- a/pacientes/agregar_imagen_evaluacion.php
+++ b/pacientes/agregar_imagen_evaluacion.php
@@ -1,0 +1,60 @@
+<?php
+header('Content-Type: application/json');
+session_start();
+if (!isset($_SESSION['rol']) || $_SESSION['rol'] == 2) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'No autorizado']);
+    exit;
+}
+require_once '../database/conexion.php';
+
+$id_eval = intval($_POST['id_eval'] ?? 0);
+if ($id_eval <= 0 || empty($_FILES['fotos']['name'][0])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Datos invalidos']);
+    exit;
+}
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$stmt = $conn->prepare("SELECT id_nino, seccion FROM exp_evaluacion_fotos WHERE id_eval_foto=?");
+$stmt->bind_param('i', $id_eval);
+$stmt->execute();
+$info = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+if (!$info) {
+    $db->closeConnection();
+    http_response_code(404);
+    echo json_encode(['success' => false, 'message' => 'Evaluación no encontrada']);
+    exit;
+}
+
+$id_nino = $info['id_nino'];
+$seccion_dir = preg_replace('/[^a-zA-Z0-9_-]/', '_', strtolower($info['seccion']));
+if ($seccion_dir === '') {
+    $seccion_dir = 'general';
+}
+$baseDir = __DIR__ . '/../uploads/pacientes/' . $id_nino . '/evaluaciones/' . $seccion_dir . '/' . $id_eval;
+if (!is_dir($baseDir)) {
+    mkdir($baseDir, 0777, true);
+}
+
+$success = true;
+foreach ($_FILES['fotos']['tmp_name'] as $i => $tmpName) {
+    if ($_FILES['fotos']['error'][$i] === UPLOAD_ERR_OK) {
+        $ext = strtolower(pathinfo($_FILES['fotos']['name'][$i], PATHINFO_EXTENSION));
+        $filename = uniqid('img_') . '.' . $ext;
+        if (move_uploaded_file($tmpName, $baseDir . '/' . $filename)) {
+            $stmt = $conn->prepare("INSERT INTO exp_evaluacion_fotos_imagenes (id_eval_foto, ruta) VALUES (?, ?)");
+            $stmt->bind_param('is', $id_eval, $filename);
+            $stmt->execute();
+            $stmt->close();
+        } else {
+            $success = false;
+        }
+    }
+}
+
+$db->closeConnection();
+echo json_encode(['success' => $success]);

--- a/pacientes/detalleEvaluacion.php
+++ b/pacientes/detalleEvaluacion.php
@@ -8,10 +8,10 @@ $db = new Database();
 $conn = $db->getConnection();
 
 $evaluaciones_fotos = [];
-$stmt = $conn->prepare("SELECT b.titulo, b.seccion, a.`ruta`, c.id, c.name, a.id_eval_foto FROM `exp_evaluacion_fotos_imagenes` a
-inner join exp_evaluacion_fotos b on b.id_eval_foto = a.id_eval_foto
-inner join nino c on c.id = b.id_nino
-WHERE a.`id_eval_foto` = ?");
+$stmt = $conn->prepare("SELECT b.titulo, b.seccion, a.ruta, c.id, c.name, a.id_eval_foto, a.id_imagen FROM exp_evaluacion_fotos_imagenes a
+INNER JOIN exp_evaluacion_fotos b ON b.id_eval_foto = a.id_eval_foto
+INNER JOIN nino c ON c.id = b.id_nino
+WHERE a.id_eval_foto = ?");
 $stmt->bind_param('i', $id);
 $stmt->execute();
 $result = $stmt->get_result();
@@ -33,35 +33,58 @@ $db->closeConnection();
             <div class="nk-content-body">
                 <?php
                 $seccion_dir = '';
+                $imagenes_por_fecha = [];
                 if (!empty($evaluaciones_fotos)) {
                     $seccion_dir = preg_replace('/[^a-zA-Z0-9_-]/', '_', strtolower($evaluaciones_fotos[0]['seccion']));
+                    foreach ($evaluaciones_fotos as $ev) {
+                        $rutaAbs = __DIR__ . '/../uploads/pacientes/' . $ev['id'] . '/evaluaciones/' . $seccion_dir . '/' . $ev['id_eval_foto'] . '/' . $ev['ruta'];
+                        $fechaClave = file_exists($rutaAbs) ? date('Y-m-d', filemtime($rutaAbs)) : 'desconocido';
+                        $imagenes_por_fecha[$fechaClave][] = $ev;
+                    }
+                    krsort($imagenes_por_fecha);
                 }
                 ?>
                 <h3><?php echo htmlspecialchars($evaluaciones_fotos[0]['titulo'] ?? ''); ?> (<?php echo htmlspecialchars($evaluaciones_fotos[0]['name'] ?? ''); ?>)</h3>
+                <?php if ($_SESSION['rol'] != 2): ?>
+                <form id="add-photo-form" class="mb-3">
+                    <div class="form-group">
+                        <input type="file" name="fotos[]" multiple accept="image/*" required>
+                        <button type="submit" class="btn btn-primary btn-sm mt-2">Agregar</button>
+                    </div>
+                </form>
+                <?php endif; ?>
                 <div class="row g-gs">
-                    <?php foreach ($evaluaciones_fotos as $ev): ?>
+                    <?php foreach ($imagenes_por_fecha as $fecha => $imgs): ?>
+                        <div class="col-12">
+                            <h5><?php echo $fecha === date('Y-m-d') ? 'Hoy' : ($fecha === date('Y-m-d', strtotime('-1 day')) ? 'Ayer' : date('d/m/Y', strtotime($fecha))); ?></h5>
+                        </div>
+                        <?php foreach ($imgs as $ev): ?>
                         <div class="col-sm-6 col-lg-4">
                             <div class="card card-bordered">
                                 <div class="card-inner">
-                                    <h6 class="title mb-2"></h6>
-
-                                    <div class="row g-2">
-                                        <div class="col-6">
+                                    <div class="row g-2 align-items-center">
+                                        <div class="col-12">
                                             <a href="../uploads/pacientes/<?php echo $ev['id']; ?>/evaluaciones/<?php echo $seccion_dir . '/' . $ev['id_eval_foto'] . '/' . $ev['ruta']; ?>" target="_blank">
-                                                <img src="../uploads/pacientes/<?php echo $ev['id']; ?>/evaluaciones/<?php echo $seccion_dir . '/' . $ev['id_eval_foto'] . '/' . $ev['ruta']; ?>" class="img-fluid" alt="">
-                                            </a></div>
+                                                <img id="img-<?php echo $ev['id_imagen']; ?>" src="../uploads/pacientes/<?php echo $ev['id']; ?>/evaluaciones/<?php echo $seccion_dir . '/' . $ev['id_eval_foto'] . '/' . $ev['ruta']; ?>" class="img-fluid" alt="">
+                                            </a>
+                                        </div>
+                                        <div class="col-12 mt-1">
+                                            <button type="button" class="btn btn-sm btn-outline-secondary rotate-img" data-target="img-<?php echo $ev['id_imagen']; ?>">Rotar</button>
+                                            <?php if ($_SESSION['rol'] != 2): ?>
+                                            <button type="button" class="btn btn-sm btn-outline-danger delete-img" data-id="<?php echo $ev['id_imagen']; ?>">Eliminar</button>
+                                            <?php endif; ?>
+                                        </div>
                                     </div>
-
                                 </div>
                             </div>
                         </div>
+                        <?php endforeach; ?>
                     <?php endforeach; ?>
-                    <?php if (empty($evaluaciones_fotos)): ?>
+                    <?php if (empty($imagenes_por_fecha)): ?>
                         <div class="col-12">
                             <p>No hay evaluaciones fotográficas.</p>
                         </div>
                     <?php endif; ?>
-
                 </div>
             </div>
         </div>
@@ -69,6 +92,59 @@ $db->closeConnection();
 
 
     <!-- wrap @e -->
+    <script>
+    <?php if ($_SESSION['rol'] != 2): ?>
+    document.getElementById('add-photo-form')?.addEventListener('submit', function(e){
+        e.preventDefault();
+        const fd = new FormData(this);
+        fd.append('id_eval', <?php echo $id; ?>);
+        fetch('agregar_imagen_evaluacion.php', {method: 'POST', body: fd})
+            .then(r => r.json())
+            .then(res => {
+                if (res.success) {
+                    Swal.fire('Guardado', '', 'success').then(() => location.reload());
+                } else {
+                    Swal.fire('Error', res.message || 'Ocurrió un error', 'error');
+                }
+            })
+            .catch(() => Swal.fire('Error', 'Ocurrió un error', 'error'));
+    });
+
+    document.querySelectorAll('.delete-img').forEach(btn => {
+        btn.addEventListener('click', function(e){
+            e.preventDefault();
+            const idImg = this.getAttribute('data-id');
+            Swal.fire({title: '¿Eliminar imagen?', icon: 'warning', showCancelButton: true, confirmButtonText: 'Sí, eliminar'})
+                .then(res => {
+                    if (res.isConfirmed) {
+                        const fd = new FormData();
+                        fd.append('id_imagen', idImg);
+                        fetch('eliminar_imagen_evaluacion.php', {method: 'POST', body: fd})
+                            .then(r => r.json())
+                            .then(resp => {
+                                if (resp.success) {
+                                    Swal.fire('Eliminado', '', 'success').then(() => location.reload());
+                                } else {
+                                    Swal.fire('Error', resp.message || 'Ocurrió un error', 'error');
+                                }
+                            })
+                            .catch(() => Swal.fire('Error', 'Ocurrió un error', 'error'));
+                    }
+                });
+        });
+    });
+    <?php endif; ?>
+
+    document.querySelectorAll('.rotate-img').forEach(btn => {
+        btn.addEventListener('click', function(){
+            const img = document.getElementById(this.getAttribute('data-target'));
+            const current = parseInt(img.getAttribute('data-rot') || '0');
+            const next = (current + 90) % 360;
+            img.style.transform = 'rotate(' + next + 'deg)';
+            img.setAttribute('data-rot', next);
+        });
+    });
+    </script>
     <?php
     include_once '../includes/footer.php';
     ?>

--- a/pacientes/eliminar_imagen_evaluacion.php
+++ b/pacientes/eliminar_imagen_evaluacion.php
@@ -1,0 +1,50 @@
+<?php
+header('Content-Type: application/json');
+session_start();
+if (!isset($_SESSION['rol']) || $_SESSION['rol'] == 2) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'No autorizado']);
+    exit;
+}
+require_once '../database/conexion.php';
+
+$id_imagen = intval($_POST['id_imagen'] ?? 0);
+if ($id_imagen <= 0) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Datos invalidos']);
+    exit;
+}
+
+$db = new Database();
+$conn = $db->getConnection();
+
+$stmt = $conn->prepare("SELECT ei.id_eval_foto, ei.ruta, ef.id_nino, ef.seccion FROM exp_evaluacion_fotos_imagenes ei JOIN exp_evaluacion_fotos ef ON ei.id_eval_foto = ef.id_eval_foto WHERE ei.id_imagen=?");
+$stmt->bind_param('i', $id_imagen);
+$stmt->execute();
+$info = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+if (!$info) {
+    $db->closeConnection();
+    http_response_code(404);
+    echo json_encode(['success' => false, 'message' => 'Imagen no encontrada']);
+    exit;
+}
+
+$seccion_dir = preg_replace('/[^a-zA-Z0-9_-]/', '_', strtolower($info['seccion']));
+if ($seccion_dir === '') {
+    $seccion_dir = 'general';
+}
+$path = __DIR__ . '/../uploads/pacientes/' . $info['id_nino'] . '/evaluaciones/' . $seccion_dir . '/' . $info['id_eval_foto'] . '/' . $info['ruta'];
+if (is_file($path)) {
+    @unlink($path);
+}
+
+$stmt = $conn->prepare("DELETE FROM exp_evaluacion_fotos_imagenes WHERE id_imagen=?");
+$stmt->bind_param('i', $id_imagen);
+$stmt->execute();
+$success = $stmt->affected_rows > 0;
+$stmt->close();
+
+$db->closeConnection();
+
+echo json_encode(['success' => $success]);


### PR DESCRIPTION
## Summary
- group evaluation photos by upload date and allow rotation
- enable adding and deleting images in evaluation detail
- expose endpoints to upload and remove evaluation images

## Testing
- `php -l pacientes/detalleEvaluacion.php pacientes/agregar_imagen_evaluacion.php pacientes/eliminar_imagen_evaluacion.php`


------
https://chatgpt.com/codex/tasks/task_e_68b619ad0ac483229ccce26108331f11