### PR TITLE
Add placeholders for Reportes, PCH and Proveedor sections

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -15,7 +15,10 @@ document.addEventListener('DOMContentLoaded', function() {
             'pacientes/paciente.php': 'menu-pacientes',
             'citas.php': 'menu-citas',
             'areas/index.php': 'menu-areas',
-            'evaluaciones.php': 'menu-evaluaciones'
+            'evaluaciones.php': 'menu-evaluaciones',
+            'reportes.php': 'menu-reportes',
+            'pch.php': 'menu-pch',
+            'proveedor.php': 'menu-proveedor'
         };
 
         const activeItemId = menuItems[currentPath];

--- a/includes/head.php
+++ b/includes/head.php
@@ -59,11 +59,11 @@ if (!isset($_SESSION['id']) && $currentPage !== 'login.php') {
     <meta charset="utf-8">
     <meta name="author" content="Jers">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="App desarrollada para el uso del personal de Cerene">
+    <meta name="description" content="App desarrollada para el uso del personal de Gank">
     <!-- Fav Icon  -->
     <link rel="shortcut icon" href="/images/favicon.png">
     <!-- Page Title  -->
-    <title>Cerene</title>
+    <title>Gank</title>
 <script>
 (function () {
   const theme = localStorage.getItem("theme");

--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -58,6 +58,24 @@ function isActive($page) {
                                         <span class="nk-menu-text">Evaluaciones</span>
                                     </a>
                                 </li><!-- .nk-menu-item -->
+                                <li class="nk-menu-item" id="menu-reportes">
+                                    <a href="/reportes.php" class="nk-menu-link">
+                                        <span class="nk-menu-icon"><em class="icon ni ni-file-text"></em></span>
+                                        <span class="nk-menu-text">Reportes</span>
+                                    </a>
+                                </li><!-- .nk-menu-item -->
+                                <li class="nk-menu-item" id="menu-pch">
+                                    <a href="/pch.php" class="nk-menu-link">
+                                        <span class="nk-menu-icon"><em class="icon ni ni-cpu"></em></span>
+                                        <span class="nk-menu-text">PCH</span>
+                                    </a>
+                                </li><!-- .nk-menu-item -->
+                                <li class="nk-menu-item" id="menu-proveedor">
+                                    <a href="/proveedor.php" class="nk-menu-link">
+                                        <span class="nk-menu-icon"><em class="icon ni ni-truck"></em></span>
+                                        <span class="nk-menu-text">Proveedor</span>
+                                    </a>
+                                </li><!-- .nk-menu-item -->
                                 <li class="nk-menu-heading">
                                     <h6 class="overline-title text-primary-alt">Configuración</h6>
                                 </li><!-- .nk-menu-heading -->

--- a/login.php
+++ b/login.php
@@ -45,7 +45,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <!-- Fav Icon  -->
     <link rel="shortcut icon" href="/images/favicon.png">
     <!-- Page Title  -->
-    <title>Inicio de sessión | Cerene</title>
+    <title>Inicio de sessión | Gank</title>
     <!-- StyleSheets  -->
     <link rel="stylesheet" href="/assets/css/dashlite.css?ver=3.3.0">
     <link id="skin-default" rel="stylesheet" href="/assets/css/theme.css?ver=3.3.0">
@@ -114,7 +114,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             <div class="nk-block nk-auth-footer">
 
                                 <div class="mt-3">
-                                    <p>&copy; 2025 Clinica Cerene.</p>
+                                    <p>&copy; 2025 Clinica Gank.</p>
                                 </div>
                             </div><!-- .nk-block -->
                         </div><!-- .nk-split-content -->

--- a/pch.php
+++ b/pch.php
@@ -1,0 +1,36 @@
+<?php
+include_once 'includes/head.php';
+date_default_timezone_set('America/Mexico_City');
+?>
+            <!-- sidebar @e -->
+            <!-- wrap @s -->
+            <div class="nk-wrap ">
+                <!-- main header @s -->
+            <?php
+                include_once 'includes/menu_superior.php';
+            ?>
+                <!-- main header @e -->
+                <!-- content @s -->
+                <div class="nk-content nk-content-fluid">
+                    <div class="container-xl wide-xl">
+                        <div class="nk-content-body">
+                            <div class="nk-block-head nk-block-head-sm">
+                                <div class="nk-block-between">
+                                    <div class="nk-block-head-content">
+                                        <h3 class="nk-block-title page-title">PCH</h3>
+                                        <div class="nk-block-des text-soft">
+                                            <p>Estamos trabajando en esta sección.</p>
+                                        </div>
+                                    </div><!-- .nk-block-head-content -->
+                                </div><!-- .nk-block-between -->
+                            </div><!-- .nk-block-head -->
+                        </div>
+                    </div>
+                </div>
+                <!-- content @e -->
+            </div>
+            <!-- wrap @e -->
+       <?php
+include_once 'includes/footer.php';
+?>
+

--- a/proveedor.php
+++ b/proveedor.php
@@ -1,0 +1,36 @@
+<?php
+include_once 'includes/head.php';
+date_default_timezone_set('America/Mexico_City');
+?>
+            <!-- sidebar @e -->
+            <!-- wrap @s -->
+            <div class="nk-wrap ">
+                <!-- main header @s -->
+            <?php
+                include_once 'includes/menu_superior.php';
+            ?>
+                <!-- main header @e -->
+                <!-- content @s -->
+                <div class="nk-content nk-content-fluid">
+                    <div class="container-xl wide-xl">
+                        <div class="nk-content-body">
+                            <div class="nk-block-head nk-block-head-sm">
+                                <div class="nk-block-between">
+                                    <div class="nk-block-head-content">
+                                        <h3 class="nk-block-title page-title">Proveedor</h3>
+                                        <div class="nk-block-des text-soft">
+                                            <p>Estamos trabajando en esta sección.</p>
+                                        </div>
+                                    </div><!-- .nk-block-head-content -->
+                                </div><!-- .nk-block-between -->
+                            </div><!-- .nk-block-head -->
+                        </div>
+                    </div>
+                </div>
+                <!-- content @e -->
+            </div>
+            <!-- wrap @e -->
+       <?php
+include_once 'includes/footer.php';
+?>
+

--- a/reportes.php
+++ b/reportes.php
@@ -1,0 +1,36 @@
+<?php
+include_once 'includes/head.php';
+date_default_timezone_set('America/Mexico_City');
+?>
+            <!-- sidebar @e -->
+            <!-- wrap @s -->
+            <div class="nk-wrap ">
+                <!-- main header @s -->
+            <?php
+                include_once 'includes/menu_superior.php';
+            ?>
+                <!-- main header @e -->
+                <!-- content @s -->
+                <div class="nk-content nk-content-fluid">
+                    <div class="container-xl wide-xl">
+                        <div class="nk-content-body">
+                            <div class="nk-block-head nk-block-head-sm">
+                                <div class="nk-block-between">
+                                    <div class="nk-block-head-content">
+                                        <h3 class="nk-block-title page-title">Reportes</h3>
+                                        <div class="nk-block-des text-soft">
+                                            <p>Estamos trabajando en esta sección.</p>
+                                        </div>
+                                    </div><!-- .nk-block-head-content -->
+                                </div><!-- .nk-block-between -->
+                            </div><!-- .nk-block-head -->
+                        </div>
+                    </div>
+                </div>
+                <!-- content @e -->
+            </div>
+            <!-- wrap @e -->
+       <?php
+include_once 'includes/footer.php';
+?>
+


### PR DESCRIPTION
## Summary
- Add navigation links for Reportes, PCH and Proveedor
- Provide placeholder pages that display an "Estamos trabajando" message
- Map new pages for active navigation highlighting
- Replace all Cerene branding with Gank

## Testing
- `php -l includes/navigation.php`
- `php -l includes/footer.php`
- `php -l reportes.php`
- `php -l pch.php`
- `php -l proveedor.php`
- `php -l includes/head.php`
- `php -l login.php`


------
https://chatgpt.com/codex/tasks/task_e_68b71784854883229fd1791145a01f63