### PR TITLE
Agregar reuniones internas al calendario en index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -38,6 +38,7 @@ ORDER BY b.name DESC;");
 
                 $citasProximas = [];
                 $citasCalendario = [];
+                $reunionesCalendario = [];
                 if ($userId > 0) {
                     $result = $conn->query("SELECT Cita.Id, Programado, nino.name, nino.id AS id_nino FROM Cita
                 INNER JOIN nino ON Cita.IdNino = nino.id
@@ -51,6 +52,23 @@ ORDER BY b.name DESC;");
                  WHERE Cita.IdUsuario = {$userId} ORDER BY Programado ASC");
                     if ($resultCalendario) {
                         $citasCalendario = $resultCalendario->fetch_all(MYSQLI_ASSOC);
+                    }
+
+                    $resultReuniones = $conn->query("SELECT
+                        ri.id,
+                        ri.titulo,
+                        ri.descripcion,
+                        ri.inicio,
+                        ri.fin,
+                        GROUP_CONCAT(u.name ORDER BY u.name SEPARATOR ', ') AS psicologos
+                    FROM ReunionInterna ri
+                    INNER JOIN ReunionInternaPsicologo rip ON rip.reunion_id = ri.id
+                    INNER JOIN Usuarios u ON u.id = rip.psicologo_id
+                    WHERE ri.fin >= NOW() AND rip.psicologo_id = {$userId}
+                    GROUP BY ri.id, ri.titulo, ri.descripcion, ri.inicio, ri.fin
+                    ORDER BY ri.inicio ASC");
+                    if ($resultReuniones) {
+                        $reunionesCalendario = $resultReuniones->fetch_all(MYSQLI_ASSOC);
                     }
                 }
 
@@ -69,10 +87,44 @@ ORDER BY b.name DESC;");
                         }
 
                         $eventosCalendario[] = [
-                            'id' => $citaCalendario['Id'],
+                            'id' => 'cita-' . $citaCalendario['Id'],
                             'title' => ucwords(strtolower($citaCalendario['name'] ?? 'Cita')),
                             'start' => $fechaEvento->format('Y-m-d\TH:i:s'),
                             'url' => 'pacientes/paciente.php?id=' . urlencode((string) $citaCalendario['id_nino']),
+                        ];
+                    }
+                }
+
+                if (!empty($reunionesCalendario)) {
+                    $tz = new DateTimeZone('America/Mexico_City');
+                    foreach ($reunionesCalendario as $reunionCalendario) {
+                        if (empty($reunionCalendario['inicio']) || empty($reunionCalendario['fin'])) {
+                            continue;
+                        }
+
+                        try {
+                            $inicioReunion = new DateTime($reunionCalendario['inicio'], $tz);
+                            $finReunion = new DateTime($reunionCalendario['fin'], $tz);
+                        } catch (Exception $e) {
+                            continue;
+                        }
+
+                        $descripcionReunion = trim((string) ($reunionCalendario['descripcion'] ?? ''));
+                        $psicologosReunion = trim((string) ($reunionCalendario['psicologos'] ?? ''));
+
+                        if ($psicologosReunion !== '') {
+                            $descripcionReunion = ($descripcionReunion !== '' ? $descripcionReunion . "\n\n" : '') . 'Participantes: ' . $psicologosReunion;
+                        }
+
+                        $eventosCalendario[] = [
+                            'id' => 'reunion-' . $reunionCalendario['id'],
+                            'title' => 'Reunión: ' . trim((string) ($reunionCalendario['titulo'] ?? 'Sin título')),
+                            'start' => $inicioReunion->format('Y-m-d\TH:i:s'),
+                            'end' => $finReunion->format('Y-m-d\TH:i:s'),
+                            'description' => $descripcionReunion,
+                            'backgroundColor' => '#E8F5E9',
+                            'borderColor' => '#2E7D32',
+                            'textColor' => '#1B4332',
                         ];
                     }
                 }


### PR DESCRIPTION
### Motivation
- Incluir las reuniones internas del psicólogo en sesión dentro del calendario de inicio para que se muestren junto a las citas existentes.
- Evitar colisiones de identificadores y diferenciar visualmente los tipos de eventos para una mejor UX.

### Description
- Se añadió una consulta SQL que obtiene reuniones vigentes (`ReunionInterna` + `ReunionInternaPsicologo` + `Usuarios`) filtradas por el usuario en sesión y con `GROUP_CONCAT` de participantes. 
- Las reuniones se integran en el arreglo `$eventosCalendario` junto con las citas, incluyendo `start`, `end`, `description` (con participantes) y colores personalizados, y se respeta la zona horaria `America/Mexico_City`.
- Se prefijan los `id` de eventos como `cita-<id>` y `reunion-<id>` para evitar colisiones y se validan fechas y campos faltantes antes de agregar eventos.
- Se mantienen las rutas de cliente para citas y se añade la metadata necesaria para que FullCalendar muestre correctamente ambos tipos de eventos.

### Testing
- Se ejecutó `php -l index.php` y la verificación de sintaxis fue satisfactoria. 
- Se intentó capturar una vista con Playwright pero falló al navegar debido a `ERR_EMPTY_RESPONSE` porque no había servidor web escuchando en `http://localhost`. 
- No se registraron errores de tiempo de compilación ni de sintaxis tras los cambios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e7d04a8083229675507fa5f8d21e)