### PR TITLE
Fix internal meetings visibility in calendar for assigned psychologist

### DIFF
--- a/index.php
+++ b/index.php
@@ -60,12 +60,15 @@ ORDER BY b.name DESC;");
                         ri.descripcion,
                         ri.inicio,
                         ri.fin,
-                        GROUP_CONCAT(u.name ORDER BY u.name SEPARATOR ', ') AS psicologos
+                        (
+                            SELECT GROUP_CONCAT(u2.name ORDER BY u2.name SEPARATOR ', ')
+                            FROM ReunionInternaPsicologo rip2
+                            INNER JOIN Usuarios u2 ON u2.id = rip2.psicologo_id
+                            WHERE rip2.reunion_id = ri.id
+                        ) AS psicologos
                     FROM ReunionInterna ri
-                    INNER JOIN ReunionInternaPsicologo rip ON rip.reunion_id = ri.id
-                    INNER JOIN Usuarios u ON u.id = rip.psicologo_id
-                    WHERE ri.fin >= NOW() AND rip.psicologo_id = {$userId}
-                    GROUP BY ri.id, ri.titulo, ri.descripcion, ri.inicio, ri.fin
+                    INNER JOIN ReunionInternaPsicologo rip_usuario ON rip_usuario.reunion_id = ri.id
+                    WHERE rip_usuario.psicologo_id = {$userId}
                     ORDER BY ri.inicio ASC");
                     if ($resultReuniones) {
                         $reunionesCalendario = $resultReuniones->fetch_all(MYSQLI_ASSOC);
@@ -98,13 +101,16 @@ ORDER BY b.name DESC;");
                 if (!empty($reunionesCalendario)) {
                     $tz = new DateTimeZone('America/Mexico_City');
                     foreach ($reunionesCalendario as $reunionCalendario) {
-                        if (empty($reunionCalendario['inicio']) || empty($reunionCalendario['fin'])) {
+                        if (empty($reunionCalendario['inicio'])) {
                             continue;
                         }
 
                         try {
                             $inicioReunion = new DateTime($reunionCalendario['inicio'], $tz);
-                            $finReunion = new DateTime($reunionCalendario['fin'], $tz);
+                            $finTexto = trim((string) ($reunionCalendario['fin'] ?? ''));
+                            $finReunion = $finTexto !== ''
+                                ? new DateTime($finTexto, $tz)
+                                : (clone $inicioReunion)->modify('+1 hour');
                         } catch (Exception $e) {
                             continue;
                         }


### PR DESCRIPTION
### Motivation
- Users assigned to internal meetings (`ReunionInterna` via `ReunionInternaPsicologo`) were not reliably shown on the dashboard calendar, and meetings without an explicit `fin` were dropped.
- The change ensures assigned psychologists see their meetings in the calendar and handles meetings missing an end time.

### Description
- Updated the internal meetings query in `index.php` to select meetings where `ReunionInternaPsicologo.psicologo_id = {$userId}` and to use a correlated subquery to aggregate participant names into `psicologos` instead of relying on a join+GROUP_CONCAT that required grouping.
- Removed the `ri.fin >= NOW()` filter so meetings assigned to the user are returned regardless of the `fin` value.
- Modified calendar event construction to only require `inicio`, and to default `end` to `inicio + 1 hour` when `fin` is empty so events are not discarded.
- Kept participant formatting by appending `Participantes: ...` to the event `description` when `psicologos` is present.

### Testing
- Ran `php -l index.php` and confirmed there are no PHP syntax errors (success).
- Executed a Playwright page navigation to `http://localhost` to capture a screenshot, which failed with `ERR_EMPTY_RESPONSE` because no local web server responded (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca00407b083229e94afb54c868c75)